### PR TITLE
feat: introducing path prefix support for SchemaTester

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Django Contract Tester
 
-This is a test utility to validate DRF (Django REST Framework) and Django Ninja test requests & responses against OpenAPI 2 and 3 schema.
+This is a test utility to validate `DRF (Django REST Framework)` and `Django Ninja` test requests & responses against `OpenAPI` versions 2.x and 3.x schemas.
 
 It has built-in support for:
 

--- a/openapi_tester/__init__.py
+++ b/openapi_tester/__init__.py
@@ -1,4 +1,5 @@
 """ Django OpenAPI Schema Tester """
+
 from .case_testers import is_camel_case, is_kebab_case, is_pascal_case, is_snake_case
 from .clients import OpenAPIClient
 from .loaders import BaseSchemaLoader, DrfSpectacularSchemaLoader, DrfYasgSchemaLoader, StaticSchemaLoader

--- a/openapi_tester/case_testers.py
+++ b/openapi_tester/case_testers.py
@@ -1,4 +1,5 @@
 """ Case testers - this module includes helper functions to test key casing """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -1,4 +1,5 @@
 """Subclass of ``APIClient`` using ``SchemaTester`` to validate responses."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -1,4 +1,5 @@
 """ Constants module """
+
 OPENAPI_PYTHON_MAPPING = {
     "boolean": bool.__name__,
     "string": str.__name__,

--- a/openapi_tester/loaders.py
+++ b/openapi_tester/loaders.py
@@ -1,4 +1,5 @@
 """ Loaders Module """
+
 from __future__ import annotations
 
 import difflib

--- a/openapi_tester/response_handler.py
+++ b/openapi_tester/response_handler.py
@@ -1,6 +1,7 @@
 """
 This module contains the concrete response handlers for both DRF and Django Ninja responses.
 """
+
 import json
 from typing import TYPE_CHECKING, Optional, Union
 

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -1,4 +1,5 @@
 """ Schema Tester """
+
 from __future__ import annotations
 
 import re

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -1,6 +1,7 @@
 """
 Utils Module - this file contains utility functions used in multiple places.
 """
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/openapi_tester/validators.py
+++ b/openapi_tester/validators.py
@@ -1,4 +1,5 @@
 """ Schema Validators """
+
 from __future__ import annotations
 
 import base64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-contract-tester"
-version = "1.2.0"
+version = "1.3.0"
 description = "Test utility for validating OpenAPI response documentation"
 authors =["Matías Cárdenas <cardenasmatias.1990@gmail.com>", "Sondre Lillebø Gundersen <sondrelg@live.no>", "Na'aman Hirschfeld <nhirschfeld@gmail.com>"]
 license = "BSD-4-Clause"
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -98,6 +97,7 @@ disable = """
     import-outside-toplevel,
     fixme,
     line-too-long,
+    too-many-arguments,
 """
 enable = "useless-suppression"
 

--- a/test_project/api/ninja/api.py
+++ b/test_project/api/ninja/api.py
@@ -43,4 +43,9 @@ def get_users(request):
     ]
 
 
+@router.patch("/{user_id}", response={200: UserOut})
+def patch_user(request, user_id: int, user: UserIn):
+    return {"id": 1, "name": "John Doe", "email": "john.doe@example.com"}
+
+
 ninja_api.add_router("/users", router)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ def pets_api_schema() -> Path:
 
 
 @pytest.fixture()
+def pets_api_schema_prefix_in_server() -> Path:
+    return TEST_ROOT / "schemas" / "openapi_v3_prefix_in_server.yaml"
+
+
+@pytest.fixture()
 def pets_post_request():
     request_body = MagicMock()
     request_body.read.return_value = b'{"name": "doggie", "tag": "dog"}'

--- a/tests/schema_converter.py
+++ b/tests/schema_converter.py
@@ -1,4 +1,5 @@
 """ Schema to Python converter """
+
 from __future__ import annotations
 
 import base64

--- a/tests/schemas/openapi_v3_prefix_in_server.yaml
+++ b/tests/schemas/openapi_v3_prefix_in_server.yaml
@@ -1,0 +1,170 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '201':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                additionalProperties: true
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from openapi_tester import OpenAPIClient, SchemaTester
+from openapi_tester.exceptions import UndocumentedSchemaSectionError
 from tests.utils import TEST_ROOT
 
 if TYPE_CHECKING:
@@ -65,3 +66,15 @@ def test_delete_user(client: OpenAPIClient):
         path="/ninja_api/users/1",
     )
     assert response.status_code == 204
+
+
+def test_patch_user_undocumented_path(client: OpenAPIClient):
+    payload = {
+        "name": "John Doe",
+    }
+    with pytest.raises(UndocumentedSchemaSectionError):
+        client.patch(
+            path="/ninja_api/users/1",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -558,3 +558,17 @@ def test_custom_validators():
         tester_with_custom_validator.test_schema_section(
             uid1_schema, uid4, test_config=OpenAPITestConfig(validators=[uuid_1_validator])
         )
+
+
+def test_get_paths_object():
+    schema = tester.loader.get_schema()
+    paths = tester.get_paths_object()
+    assert paths == schema["paths"]
+
+
+def test_get_paths_object_path_prefix(pets_api_schema: Path):
+    path_prefix = "/path/prefix"
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema), path_prefix=path_prefix)
+    paths_object = schema_tester.get_paths_object()
+
+    assert list(paths_object.keys()) == [f"{path_prefix}/api/pets", f"{path_prefix}/api/pets/{{id}}"]


### PR DESCRIPTION
Introducing support for passing a `path_prefix` to `SchemaTester` class. 

In some cases where many APIs shared the same path prefix (e.g. `api/v1/`), it could be that this is included in the server URL to avoid repetition. 
Given this prefix might be part of the `urls` paths defined in Django, it leads to the library to not find the corresponding paths in the schema (e.g. url path in django `/api/v1/pets` while in the schema the path is just `/pets`). 

This PR adds a new argument to allow passing a prefix to match with django paths, in case this one is appended in the `server` url of the OpenAPI specification. 