### PR TITLE
feat: update error messages

### DIFF
--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-
 from typing import TYPE_CHECKING
 
 from rest_framework.test import APIClient

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -78,5 +78,5 @@ class OpenAPIClient(APIClient):
         try:
             return json.dumps(data)
         except (TypeError, OverflowError):
-            """Data is already serialized"""
+            # Data is already serialized
             return data

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -37,31 +37,31 @@ class OpenAPIClient(APIClient):
     # pylint: disable=W0622
     def post(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
-            data = json.dumps(data)
+            data = self._serialize(data)
         return super().post(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
     # pylint: disable=W0622
     def put(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
-            data = json.dumps(data)
+            data = self._serialize(data)
         return super().put(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
     # pylint: disable=W0622
     def patch(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
-            data = json.dumps(data)
+            data = self._serialize(data)
         return super().patch(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
     # pylint: disable=W0622
     def delete(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
-            data = json.dumps(data)
+            data = self._serialize(data)
         return super().delete(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
     # pylint: disable=W0622
     def options(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
-            data = json.dumps(data)
+            data = self._serialize(data)
         return super().options(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
     @staticmethod
@@ -72,3 +72,11 @@ class OpenAPIClient(APIClient):
     def _schema_tester_factory() -> SchemaTester:
         """Factory of default ``SchemaTester`` instances."""
         return SchemaTester()
+
+    @staticmethod
+    def _serialize(data):
+        try:
+            return json.dumps(data)
+        except (TypeError, OverflowError):
+            """Data is already serialized"""
+            return data

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -35,34 +35,109 @@ class OpenAPIClient(APIClient):
         return response
 
     # pylint: disable=W0622
-    def post(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
+    def post(
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type="application/json",
+        follow=False,
+        **extra,
+    ):
         if data and content_type == "application/json":
             data = self._serialize(data)
-        return super().post(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+        return super().post(
+            path,
+            data=data,
+            format=format,
+            content_type=content_type,
+            follow=follow,
+            **extra,
+        )
 
     # pylint: disable=W0622
-    def put(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
+    def put(
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type="application/json",
+        follow=False,
+        **extra,
+    ):
         if data and content_type == "application/json":
             data = self._serialize(data)
-        return super().put(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+        return super().put(
+            path,
+            data=data,
+            format=format,
+            content_type=content_type,
+            follow=follow,
+            **extra,
+        )
 
     # pylint: disable=W0622
-    def patch(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
+    def patch(
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type="application/json",
+        follow=False,
+        **extra,
+    ):
         if data and content_type == "application/json":
             data = self._serialize(data)
-        return super().patch(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+        return super().patch(
+            path,
+            data=data,
+            format=format,
+            content_type=content_type,
+            follow=follow,
+            **extra,
+        )
 
     # pylint: disable=W0622
-    def delete(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
+    def delete(
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type="application/json",
+        follow=False,
+        **extra,
+    ):
         if data and content_type == "application/json":
             data = self._serialize(data)
-        return super().delete(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+        return super().delete(
+            path,
+            data=data,
+            format=format,
+            content_type=content_type,
+            follow=follow,
+            **extra,
+        )
 
     # pylint: disable=W0622
-    def options(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
+    def options(
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type="application/json",
+        follow=False,
+        **extra,
+    ):
         if data and content_type == "application/json":
             data = self._serialize(data)
-        return super().options(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+        return super().options(
+            path,
+            data=data,
+            format=format,
+            content_type=content_type,
+            follow=follow,
+            **extra,
+        )
 
     @staticmethod
     def _is_successful_response(response: Response) -> bool:

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -34,27 +34,32 @@ class OpenAPIClient(APIClient):
         self.schema_tester.validate_response(response)
         return response
 
-    def post(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+    # pylint: disable=W0622
+    def post(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
             data = json.dumps(data)
         return super().post(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
-    def put(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+    # pylint: disable=W0622
+    def put(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
             data = json.dumps(data)
         return super().put(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
-    def patch(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+    # pylint: disable=W0622
+    def patch(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
             data = json.dumps(data)
         return super().patch(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
-    def delete(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+    # pylint: disable=W0622
+    def delete(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
             data = json.dumps(data)
         return super().delete(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
-    def options(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+    # pylint: disable=W0622
+    def options(self, path, data=None, format=None, content_type="application/json", follow=False, **extra):
         if data and content_type == "application/json":
             data = json.dumps(data)
         return super().options(path, data=data, format=format, content_type=content_type, follow=follow, **extra)

--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from typing import TYPE_CHECKING
 
 from rest_framework.test import APIClient
@@ -32,6 +34,31 @@ class OpenAPIClient(APIClient):
             self.schema_tester.validate_request(response)
         self.schema_tester.validate_response(response)
         return response
+
+    def post(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+        if data and content_type == "application/json":
+            data = json.dumps(data)
+        return super().post(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+
+    def put(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+        if data and content_type == "application/json":
+            data = json.dumps(data)
+        return super().put(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+
+    def patch(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+        if data and content_type == "application/json":
+            data = json.dumps(data)
+        return super().patch(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+
+    def delete(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+        if data and content_type == "application/json":
+            data = json.dumps(data)
+        return super().delete(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
+
+    def options(self, path, data=None, format=None, content_type="application/json", follow=False, **extra) -> Response:
+        if data and content_type == "application/json":
+            data = json.dumps(data)
+        return super().options(path, data=data, format=format, content_type=content_type, follow=follow, **extra)
 
     @staticmethod
     def _is_successful_response(response: Response) -> bool:

--- a/openapi_tester/config.py
+++ b/openapi_tester/config.py
@@ -13,5 +13,5 @@ class OpenAPITestConfig:
     case_tester: Optional[Callable[[str], None]] = None
     ignore_case: Optional[List[str]] = None
     validators: Any = None
-    reference: str = "init"
+    reference: str = "root"
     http_message: str = "response"

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -36,9 +36,7 @@ VALIDATE_MAX_ARRAY_LENGTH_ERROR = "The length of the array {data} exceeds the sp
 VALIDATE_MINIMUM_NUMBER_OF_PROPERTIES_ERROR = "The number of properties in {data} is fewer than the specified minimum number of properties of {min_length}"
 VALIDATE_MAXIMUM_NUMBER_OF_PROPERTIES_ERROR = "The number of properties in {data} exceeds the specified maximum number of properties of {max_length}"
 VALIDATE_UNIQUE_ITEMS_ERROR = "The array {data} must contain unique items only"
-VALIDATE_NONE_ERROR = (
-    "A property received a null value in the {http_message} data, but is a non-nullable object in the schema definition"
-)
+VALIDATE_NONE_ERROR = "A property received a null value in the {http_message} data, but is a non-nullable object in the schema definition"
 VALIDATE_MISSING_KEY_ERROR = (
     "The following property was found in the schema definition, "
     'but is missing from the {http_message} data: "{missing_key}"'

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -36,9 +36,17 @@ VALIDATE_MAX_ARRAY_LENGTH_ERROR = "The length of the array {data} exceeds the sp
 VALIDATE_MINIMUM_NUMBER_OF_PROPERTIES_ERROR = "The number of properties in {data} is fewer than the specified minimum number of properties of {min_length}"
 VALIDATE_MAXIMUM_NUMBER_OF_PROPERTIES_ERROR = "The number of properties in {data} exceeds the specified maximum number of properties of {max_length}"
 VALIDATE_UNIQUE_ITEMS_ERROR = "The array {data} must contain unique items only"
-VALIDATE_NONE_ERROR = "Received a null value for a non-nullable schema object"
+VALIDATE_NONE_ERROR = (
+    'A property received a null value in the {http_message} data, '
+    'but is a non-nullable object in the schema definition'
+)
 VALIDATE_MISSING_KEY_ERROR = (
-    'The following property is missing in the {http_message} data: "{missing_key}"'
+    'The following property was found in the schema definition, '
+    'but is missing from the {http_message} data: "{missing_key}"'
+)
+VALIDATE_EXCESS_KEY_ERROR = (
+    'The following property was found in the {http_message} data, '
+    'but is missing from the schema definition: "{excess_key}"'
 )
 VALIDATE_EXCESS_KEY_ERROR = 'The following property was found in the {http_message}, but is missing from the schema definition: "{excess_key}"'
 VALIDATE_WRITE_ONLY_RESPONSE_KEY_ERROR = 'The following property was found in the response, but is documented as being "writeOnly": "{write_only_key}"'

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -37,15 +37,14 @@ VALIDATE_MINIMUM_NUMBER_OF_PROPERTIES_ERROR = "The number of properties in {data
 VALIDATE_MAXIMUM_NUMBER_OF_PROPERTIES_ERROR = "The number of properties in {data} exceeds the specified maximum number of properties of {max_length}"
 VALIDATE_UNIQUE_ITEMS_ERROR = "The array {data} must contain unique items only"
 VALIDATE_NONE_ERROR = (
-    'A property received a null value in the {http_message} data, '
-    'but is a non-nullable object in the schema definition'
+    "A property received a null value in the {http_message} data, but is a non-nullable object in the schema definition"
 )
 VALIDATE_MISSING_KEY_ERROR = (
-    'The following property was found in the schema definition, '
+    "The following property was found in the schema definition, "
     'but is missing from the {http_message} data: "{missing_key}"'
 )
 VALIDATE_EXCESS_KEY_ERROR = (
-    'The following property was found in the {http_message} data, '
+    "The following property was found in the {http_message} data, "
     'but is missing from the schema definition: "{excess_key}"'
 )
 VALIDATE_EXCESS_KEY_ERROR = 'The following property was found in the {http_message}, but is missing from the schema definition: "{excess_key}"'

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -45,7 +45,6 @@ VALIDATE_EXCESS_KEY_ERROR = (
     "The following property was found in the {http_message} data, "
     'but is missing from the schema definition: "{excess_key}"'
 )
-VALIDATE_EXCESS_KEY_ERROR = 'The following property was found in the {http_message}, but is missing from the schema definition: "{excess_key}"'
 VALIDATE_WRITE_ONLY_RESPONSE_KEY_ERROR = 'The following property was found in the response, but is documented as being "writeOnly": "{write_only_key}"'
 VALIDATE_ONE_OF_ERROR = "Expected data to match one and only one of the oneOf schema types; found {matches} matches"
 VALIDATE_ANY_OF_ERROR = "Expected data to match one or more of the documented anyOf schema types, but found no matches"

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -598,7 +598,9 @@ class SchemaTester:
                     test_config=drill_down_test_config,
                 )
 
-    def test_openapi_array(self, schema_section: dict[str, Any], data: dict, test_config: OpenAPITestConfig) -> None:
+    def test_openapi_array(
+        self, schema_section: dict[str, Any], data: dict, test_config: OpenAPITestConfig
+    ) -> None:
         for array_item in data:
             array_item_test_config = copy(test_config)
             array_item_test_config.reference = f"{test_config.reference}"
@@ -633,9 +635,12 @@ class SchemaTester:
                 test_config.http_message = "request"
             else:
                 test_config = OpenAPITestConfig(
-                    http_message="request", reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > request"
+                    http_message="request",
+                    reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > request",
                 )
-            request_body_schema = self.get_request_body_schema_section(request, test_config=test_config)
+            request_body_schema = self.get_request_body_schema_section(
+                request, test_config=test_config
+            )
 
             if request_body_schema:
                 self.test_schema_section(
@@ -669,7 +674,9 @@ class SchemaTester:
                 http_message="response",
                 reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > response > {response.status_code}",
             )
-        response_schema = self.get_response_schema_section(response_handler, test_config=test_config)
+        response_schema = self.get_response_schema_section(
+            response_handler, test_config=test_config
+        )
         self.test_schema_section(
             schema_section=response_schema,
             data=response_handler.data,

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -446,10 +446,10 @@ class SchemaTester:
                 # If data is None and nullable, we return early
                 return
             raise DocumentationError(
-                f"{VALIDATE_NONE_ERROR.format(http_message=test_config.http_message)}\n\n"
-                f"Reference: "
+                f"{VALIDATE_NONE_ERROR.format(http_message=test_config.http_message)}"
+                f"\n\nReference:"
                 f"\n\n{test_config.reference}"
-                f"\n\n Schema description:\n  {json.dumps(schema_section, indent=4)}"
+                f"\n\nSchema description:\n  {json.dumps(schema_section, indent=4)}"
                 "\n\nHint: Return a valid type, or document the value as nullable"
             )
         schema_section = normalize_schema_section(schema_section)
@@ -551,8 +551,8 @@ class SchemaTester:
                     f"{VALIDATE_MISSING_KEY_ERROR.format(missing_key=key, http_message=test_config.http_message)}"
                     "\n\nReference:"
                     f"\n\n{test_config.reference} > {key}"
-                    f"\n\n {test_config.http_message.capitalize()} body:\n  {json.dumps(data, indent=4)}"
-                    f"\n Schema section:\n  {json.dumps(properties, indent=4)}"
+                    f"\n\n{test_config.http_message.capitalize()} body:\n  {json.dumps(data, indent=4)}"
+                    f"\nSchema section:\n  {json.dumps(properties, indent=4)}"
                     f"\n\nHint: Remove the key from your OpenAPI docs, or"
                     f" include it in your API {test_config.http_message}"
                 )
@@ -562,17 +562,18 @@ class SchemaTester:
                 raise DocumentationError(
                     f"{VALIDATE_EXCESS_KEY_ERROR.format(excess_key=key, http_message=test_config.http_message)}"
                     "\n\nReference:"
-                    f"\n\n {test_config.http_message.capitalize()} body:\n  ${json.dumps(data, indent=4)}"
-                    f"\n\n Schema section:\n  ${json.dumps(properties, indent=4)}"
+                    f"\n\n{test_config.reference} > {key}"
+                    f"\n\n{test_config.http_message.capitalize()} body:\n  {json.dumps(data, indent=4)}"
+                    f"\n\nSchema section:\n  {json.dumps(properties, indent=4)}"
                     f"\n\nHint: Remove the key from your API"
                     f" {test_config.http_message}, or include it in your OpenAPI docs"
                 )
             if key in write_only_properties:
                 raise DocumentationError(
                     f"{VALIDATE_WRITE_ONLY_RESPONSE_KEY_ERROR.format(write_only_key=key)}\n\nReference:"
-                    f" {test_config.reference} > {key}"
-                    f"\n\n {test_config.http_message.capitalize()} body:\n  {json.dumps(data, indent=4)}"
-                    f"\n Schema section:\n  {json.dumps(properties, indent=4)}"
+                    f"\n\n{test_config.reference} > {key}"
+                    f"\n\n{test_config.http_message.capitalize()} body:\n  {json.dumps(data, indent=4)}"
+                    f"\nSchema section:\n  {json.dumps(properties, indent=4)}"
                     f"\n\nHint: Remove the key from your API {test_config.http_message}, or"
                     ' remove the "WriteOnly" restriction'
                 )

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -171,9 +171,7 @@ class SchemaTester:
         return paths_object
 
     def get_response_schema_section(
-        self,
-        response_handler: ResponseHandler,
-        test_config: OpenAPITestConfig
+        self, response_handler: ResponseHandler, test_config: OpenAPITestConfig
     ) -> dict[str, Any]:
         """
         Fetches the response section of a schema, wrt. the route, method, status code, and schema version.
@@ -195,9 +193,8 @@ class SchemaTester:
             paths_object,
             parameterized_path,
             (
-                f"\n\n{test_config.reference}"
-                f"\n\nUndocumented route {parameterized_path}."
-                f"\n\nDocumented routes: " + "\n\t• ".join(paths_object.keys())
+                f"\n\n{test_config.reference}\n\nUndocumented route {parameterized_path}.\n\nDocumented routes: "
+                + "\n\t• ".join(paths_object.keys())
             ),
         )
 
@@ -207,7 +204,7 @@ class SchemaTester:
             (
                 f"\n\n{test_config.reference}"
                 f"\n\nUndocumented method: {response_method}."
-                f"\n\nDocumented methods: "
+                "\n\nDocumented methods: "
                 f"{[method.lower() for method in route_object.keys() if method.lower() != 'parameters']}."
             ),
         )
@@ -260,7 +257,9 @@ class SchemaTester:
             )
         return {}
 
-    def get_request_body_schema_section(self, request: dict[str, Any], test_config: OpenAPITestConfig) -> dict[str, Any]:
+    def get_request_body_schema_section(
+        self, request: dict[str, Any], test_config: OpenAPITestConfig
+    ) -> dict[str, Any]:
         """
         Fetches the request section of a schema.
 
@@ -278,9 +277,8 @@ class SchemaTester:
             paths_object,
             parameterized_path,
             (
-                f"\n\n{test_config.reference}"
-                f"\n\nUndocumented route {parameterized_path}."
-                f"\n\nDocumented routes: " + "\n\t• ".join(paths_object.keys())
+                f"\n\n{test_config.reference}\n\nUndocumented route {parameterized_path}.\n\nDocumented routes: "
+                + "\n\t• ".join(paths_object.keys())
             ),
         )
 
@@ -290,7 +288,7 @@ class SchemaTester:
             (
                 f"\n\n{test_config.reference}"
                 f"\n\nUndocumented method: {request_method}."
-                f"\n\nDocumented methods: "
+                "\n\nDocumented methods: "
                 f"{[method.lower() for method in route_object.keys() if method.lower() != 'parameters']}."
             ),
         )
@@ -447,7 +445,7 @@ class SchemaTester:
                 return
             raise DocumentationError(
                 f"{VALIDATE_NONE_ERROR.format(http_message=test_config.http_message)}"
-                f"\n\nReference:"
+                "\n\nReference:"
                 f"\n\n{test_config.reference}"
                 f"\n\nSchema description:\n  {json.dumps(schema_section, indent=4)}"
                 "\n\nHint: Return a valid type, or document the value as nullable"
@@ -499,7 +497,7 @@ class SchemaTester:
             if error:
                 raise DocumentationError(
                     f"\n\n{error}"
-                    f"\n\nReference: "
+                    "\n\nReference: "
                     f"\n\n{test_config.reference}"
                     f"\n\n {test_config.http_message.capitalize()} value:\n  {data}"
                     f"\n Schema description:\n  {schema_section}"
@@ -553,7 +551,7 @@ class SchemaTester:
                     f"\n\n{test_config.reference} > {key}"
                     f"\n\n{test_config.http_message.capitalize()} body:\n  {json.dumps(data, indent=4)}"
                     f"\nSchema section:\n  {json.dumps(properties, indent=4)}"
-                    f"\n\nHint: Remove the key from your OpenAPI docs, or"
+                    "\n\nHint: Remove the key from your OpenAPI docs, or"
                     f" include it in your API {test_config.http_message}"
                 )
         for key in request_response_keys:
@@ -565,7 +563,7 @@ class SchemaTester:
                     f"\n\n{test_config.reference} > {key}"
                     f"\n\n{test_config.http_message.capitalize()} body:\n  {json.dumps(data, indent=4)}"
                     f"\n\nSchema section:\n  {json.dumps(properties, indent=4)}"
-                    f"\n\nHint: Remove the key from your API"
+                    "\n\nHint: Remove the key from your API"
                     f" {test_config.http_message}, or include it in your OpenAPI docs"
                 )
             if key in write_only_properties:
@@ -630,8 +628,7 @@ class SchemaTester:
                 test_config.http_message = "request"
             else:
                 test_config = OpenAPITestConfig(
-                    http_message="request",
-                    reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > request"
+                    http_message="request", reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > request"
                 )
             request_body_schema = self.get_request_body_schema_section(request, test_config=test_config)  # type: ignore
 
@@ -665,7 +662,7 @@ class SchemaTester:
             request = response.request
             test_config = OpenAPITestConfig(
                 http_message="response",
-                reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > response > {response.status_code}"
+                reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > response > {response.status_code}",
             )
         response_schema = self.get_response_schema_section(response_handler, test_config=test_config)
         self.test_schema_section(

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -399,6 +399,7 @@ class SchemaTester:
         """
         openapi_schema_3_nullable = "nullable"
         swagger_2_nullable = "x-nullable"
+        openapi_schema_3_1_type_nullable = "null"
         if "oneOf" in schema_item:
             one_of: list[dict[str, Any]] = schema_item.get("oneOf", [])
             return any(
@@ -413,6 +414,10 @@ class SchemaTester:
                 for schema in any_of
                 for nullable_key in [openapi_schema_3_nullable, swagger_2_nullable]
             )
+        if "type" in schema_item and isinstance(schema_item["type"], list):
+            types: list[str] = schema_item["type"]
+            return openapi_schema_3_1_type_nullable in types
+
         return any(
             nullable_key in schema_item and schema_item[nullable_key]
             for nullable_key in [openapi_schema_3_nullable, swagger_2_nullable]

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -623,14 +623,14 @@ class SchemaTester:
         response_handler = ResponseHandlerFactory.create(response)
         if self.is_openapi_schema():
             # TODO: Implement for other schema types
-            request = response.request
+            request = response.request  # type: ignore
             if test_config:
                 test_config.http_message = "request"
             else:
                 test_config = OpenAPITestConfig(
                     http_message="request", reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > request"
                 )
-            request_body_schema = self.get_request_body_schema_section(request, test_config=test_config)  # type: ignore
+            request_body_schema = self.get_request_body_schema_section(request, test_config=test_config)
 
             if request_body_schema:
                 self.test_schema_section(
@@ -659,7 +659,7 @@ class SchemaTester:
         if test_config:
             test_config.http_message = "response"
         else:
-            request = response.request
+            request = response.request  # type: ignore
             test_config = OpenAPITestConfig(
                 http_message="response",
                 reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > response > {response.status_code}",

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -624,10 +624,10 @@ class SchemaTester:
         response_handler = ResponseHandlerFactory.create(response)
         if self.is_openapi_schema():
             # TODO: Implement for other schema types
+            request = response.request
             if test_config:
                 test_config.http_message = "request"
             else:
-                request = response.request
                 test_config = OpenAPITestConfig(
                     http_message="request",
                     reference=f"{request['REQUEST_METHOD']} {request['PATH_INFO']} > request"

--- a/openapi_tester/validators.py
+++ b/openapi_tester/validators.py
@@ -91,12 +91,23 @@ VALIDATOR_MAP: dict[str, Callable] = {
 
 
 def validate_type(schema_section: dict[str, Any], data: Any) -> str | None:
-    schema_type: str = schema_section.get("type", "object")
-    if not VALIDATOR_MAP[schema_type](data):
-        an_articles = ["integer", "object", "array"]
+    an_articles = ["integer", "object", "array"]
+    schema_types: str = schema_section.get("type", "object")
+    if isinstance(schema_types, list):
+        has_type = False
+        for schema_type in schema_types:
+            if VALIDATOR_MAP[schema_type](data):
+                return None
+        if not has_type:
+            return VALIDATE_TYPE_ERROR.format(
+                article="a" if schema_types not in an_articles else "an",
+                type=schema_types,
+                received=f'"{data}"' if isinstance(data, str) else data,
+            )
+    if not VALIDATOR_MAP[schema_types](data):
         return VALIDATE_TYPE_ERROR.format(
-            article="a" if schema_type not in an_articles else "an",
-            type=schema_type,
+            article="a" if schema_types not in an_articles else "an",
+            type=schema_types,
             received=f'"{data}"' if isinstance(data, str) else data,
         )
     return None

--- a/test_project/api/serializers.py
+++ b/test_project/api/serializers.py
@@ -9,7 +9,7 @@ class VehicleSerializer(serializers.Serializer):
 
 
 class PetsSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=254)
+    name = serializers.CharField(max_length=254, required=False, allow_null=True)
     tag = serializers.CharField(max_length=254, required=False, allow_null=True)
 
 

--- a/test_project/api/serializers.py
+++ b/test_project/api/serializers.py
@@ -10,7 +10,7 @@ class VehicleSerializer(serializers.Serializer):
 
 class PetsSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=254)
-    tag = serializers.CharField(max_length=254, required=False)
+    tag = serializers.CharField(max_length=254, required=False, allow_null=True)
 
 
 class ItemSerializer(serializers.Serializer):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,11 @@ def pets_api_schema_prefix_in_server() -> Path:
 
 
 @pytest.fixture
+def cars_api_schema() -> Path:
+    return TEST_ROOT / "schemas" / "spectactular_reference_schema.yaml"
+
+
+@pytest.fixture
 def pets_post_request():
     request_body = MagicMock()
     request_body.read.return_value = b'{"name": "doggie", "tag": "dog"}'

--- a/tests/schema_converter.py
+++ b/tests/schema_converter.py
@@ -82,6 +82,11 @@ class SchemaToPythonConverter:
         minimum: int | float | None = schema_object.get("minimum")
         maximum: int | float | None = schema_object.get("maximum")
         enum: list | None = schema_object.get("enum")
+        if isinstance(schema_type, list):
+            for s_type in schema_type:
+                return (
+                    faker_handler_map[s_type]()
+                )
         if enum:
             return random.sample(enum, 1)[0]
         if schema_type in ["integer", "number"] and (

--- a/tests/schema_converter.py
+++ b/tests/schema_converter.py
@@ -84,9 +84,7 @@ class SchemaToPythonConverter:
         enum: list | None = schema_object.get("enum")
         if isinstance(schema_type, list):
             for s_type in schema_type:
-                return (
-                    faker_handler_map[s_type]()
-                )
+                return faker_handler_map[s_type]()
         if enum:
             return random.sample(enum, 1)[0]
         if schema_type in ["integer", "number"] and (

--- a/tests/schemas/openapi_v3_reference_schema.yaml
+++ b/tests/schemas/openapi_v3_reference_schema.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: "3.1.0"
 info:
   version: 1.0.0
   title: Swagger Petstore
@@ -153,7 +153,9 @@ components:
         - name
       properties:
         name:
-          type: string
+          type:
+            - string
+            - 'null'
         tag:
           type: string
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -50,7 +50,7 @@ def test_post_request(openapi_client):
 def test_request_validation_is_not_triggered_for_bad_requests(pets_api_schema: "Path"):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
-    response = openapi_client.post(path="/api/pets", data={"tag": "doggie"})
+    response = openapi_client.post(path="/api/pets", data={"name": False})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -42,7 +42,9 @@ def test_get_request(cars_api_schema: "Path"):
 
 
 def test_post_request(openapi_client):
-    response = openapi_client.post(path="/api/v1/vehicles", data={"vehicle_type": "suv"})
+    response = openapi_client.post(
+        path="/api/v1/vehicles", data={"vehicle_type": "suv"}
+    )
 
     assert response.status_code == status.HTTP_201_CREATED
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -33,78 +33,62 @@ def test_init_schema_tester_passed():
     assert client.schema_tester is schema_tester
 
 
-@pytest.mark.parametrize(
-    ("generic_kwargs", "expected_status_code"),
-    [
-        (
-            {"method": "GET", "path": "/api/v1/cars/correct"},
-            status.HTTP_200_OK,
-        ),
-        (
-            {
-                "method": "POST",
-                "path": "/api/v1/vehicles",
-                "data": json.dumps({"vehicle_type": "suv"}),
-                "content_type": "application/json",
-            },
-            status.HTTP_201_CREATED,
-        ),
-    ],
-)
-def test_request(openapi_client, generic_kwargs, expected_status_code):
-    """Ensure ``SchemaTester`` doesn't raise exception when response valid."""
-    response = openapi_client.generic(**generic_kwargs)
+def test_get_request(cars_api_schema: "Path"):
+    schema_tester = SchemaTester(schema_file_path=str(cars_api_schema))
+    openapi_client = OpenAPIClient(schema_tester=schema_tester)
+    response = openapi_client.get(
+        path="/api/v1/cars/correct"
+    )
 
-    assert response.status_code == expected_status_code
+    assert response.status_code == status.HTTP_200_OK
 
 
-@pytest.mark.parametrize(
-    ("generic_kwargs", "expected_status_code"),
-    [
-        (
-            {
-                "method": "POST",
-                "path": "/api/pets",
-                "data": json.dumps({"name": "doggie"}),
-                "content_type": "application/json",
-            },
-            status.HTTP_201_CREATED,
-        ),
-        (
-            {
-                "method": "POST",
-                "path": "/api/pets",
-                "data": json.dumps({"tag": "doggie"}),
-                "content_type": "application/json",
-            },
-            status.HTTP_400_BAD_REQUEST,
-        ),
-    ],
-)
-def test_request_body(generic_kwargs, expected_status_code, pets_api_schema: "Path"):
-    """Ensure ``SchemaTester`` doesn't raise exception when request valid.
-    Additionally, request validation should be performed only in successful responses."""
+def test_post_request(openapi_client):
+    response = openapi_client.post(
+        path="/api/v1/vehicles",
+        data={
+            "vehicle_type": "suv"
+        }
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_request_validation_is_not_triggered_for_bad_requests(pets_api_schema: "Path"):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
-    response = openapi_client.generic(**generic_kwargs)
+    response = openapi_client.post(
+        path="/api/pets",
+        data={
+            "tag": "doggie"
+        }
+    )
 
-    assert response.status_code == expected_status_code
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_request_body_extra_non_documented_field(pets_api_schema: "Path"):
-    """Ensure ``SchemaTester`` raises exception when request is successfull but an
+    """Ensure ``SchemaTester`` raises exception when request is successful but an
     extra field non-documented was sent."""
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
-    kwargs = {
-        "method": "POST",
-        "path": "/api/pets",
-        "data": json.dumps({"name": "doggie", "age": 1}),
-        "content_type": "application/json",
-    }
 
     with pytest.raises(DocumentationError):
-        openapi_client.generic(**kwargs)  # type: ignore
+        openapi_client.post(
+            path="/api/pets",
+            data={"name": "doggie", "age": 1}
+        )
+
+
+def test_request_body_non_null_fields(pets_api_schema: "Path"):
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    openapi_client = OpenAPIClient(schema_tester=schema_tester)
+
+    with pytest.raises(DocumentationError):
+        openapi_client.post(
+            path="/api/pets",
+            data={"name":  "doggie", "tag": None}
+        )
 
 
 def test_request_on_empty_list(openapi_client):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -73,6 +73,20 @@ def test_request_body_non_null_fields(pets_api_schema: "Path"):
         openapi_client.post(path="/api/pets", data={"name": "doggie", "tag": None})
 
 
+def test_request_multiple_types_supported(pets_api_schema: "Path"):
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    openapi_client = OpenAPIClient(schema_tester=schema_tester)
+
+    openapi_client.post(path="/api/pets", data={"name": "doggie", "tag": "pet"})
+
+
+def test_request_multiple_types_null_type_allowed(pets_api_schema: "Path"):
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    openapi_client = OpenAPIClient(schema_tester=schema_tester)
+
+    openapi_client.post(path="/api/pets", data={"name": None, "tag": "pet"})
+
+
 def test_request_on_empty_list(openapi_client):
     """Ensure ``SchemaTester`` doesn't raise exception when response is empty list."""
     response = openapi_client.generic(

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -36,20 +36,13 @@ def test_init_schema_tester_passed():
 def test_get_request(cars_api_schema: "Path"):
     schema_tester = SchemaTester(schema_file_path=str(cars_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
-    response = openapi_client.get(
-        path="/api/v1/cars/correct"
-    )
+    response = openapi_client.get(path="/api/v1/cars/correct")
 
     assert response.status_code == status.HTTP_200_OK
 
 
 def test_post_request(openapi_client):
-    response = openapi_client.post(
-        path="/api/v1/vehicles",
-        data={
-            "vehicle_type": "suv"
-        }
-    )
+    response = openapi_client.post(path="/api/v1/vehicles", data={"vehicle_type": "suv"})
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -57,12 +50,7 @@ def test_post_request(openapi_client):
 def test_request_validation_is_not_triggered_for_bad_requests(pets_api_schema: "Path"):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
-    response = openapi_client.post(
-        path="/api/pets",
-        data={
-            "tag": "doggie"
-        }
-    )
+    response = openapi_client.post(path="/api/pets", data={"tag": "doggie"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -74,10 +62,7 @@ def test_request_body_extra_non_documented_field(pets_api_schema: "Path"):
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
 
     with pytest.raises(DocumentationError):
-        openapi_client.post(
-            path="/api/pets",
-            data={"name": "doggie", "age": 1}
-        )
+        openapi_client.post(path="/api/pets", data={"name": "doggie", "age": 1})
 
 
 def test_request_body_non_null_fields(pets_api_schema: "Path"):
@@ -85,10 +70,7 @@ def test_request_body_non_null_fields(pets_api_schema: "Path"):
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
 
     with pytest.raises(DocumentationError):
-        openapi_client.post(
-            path="/api/pets",
-            data={"name":  "doggie", "tag": None}
-        )
+        openapi_client.post(path="/api/pets", data={"name": "doggie", "tag": None})
 
 
 def test_request_on_empty_list(openapi_client):

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -42,7 +42,7 @@ def test_create_user(client: OpenAPIClient):
     }
     response = client.post(
         path="/ninja_api/users/",
-        data=json.dumps(payload),
+        data=payload,
         content_type="application/json",
     )
     assert response.status_code == 201
@@ -57,7 +57,7 @@ def test_update_user(client: OpenAPIClient):
     }
     response = client.put(
         path="/ninja_api/users/1",
-        data=json.dumps(payload),
+        data=payload,
         content_type="application/json",
     )
     assert response.status_code == 200

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -192,8 +192,8 @@ class TestTestOpenAPIObjectErrors:
     def test_missing_schema_key_error(self):
         expected_error_message = (
             'The following property was found in the response data, but is missing from the schema definition: "two"'
-            '\n\nReference:'
-            '\n\nPOST /endpoint > response > two'
+            "\n\nReference:"
+            "\n\nPOST /endpoint > response > two"
             '\n\nResponse body:\n  {\n    "one": 1,\n    "two": 2\n}'
             '\n\nSchema section:\n  {\n    "one": {\n        "type": "int"\n    }\n}'
             "\n\nHint: Remove the key from your API response, or include it in your OpenAPI docs"
@@ -209,8 +209,8 @@ class TestTestOpenAPIObjectErrors:
     def test_key_in_write_only_properties_error(self):
         expected_error_message = (
             'The following property was found in the response, but is documented as being "writeOnly": "one"'
-            '\n\nReference:'
-            '\n\nPOST /endpoint > response > one'
+            "\n\nReference:"
+            "\n\nPOST /endpoint > response > one"
             '\n\nResponse body:\n  {\n    "one": 1\n}'
             '\nSchema section:\n  {\n    "one": {\n        "type": "int",\n        "writeOnly": true\n    }\n}'
             '\n\nHint: Remove the key from your API response, or remove the "WriteOnly" restriction'
@@ -235,9 +235,7 @@ def test_null_error():
     tester = SchemaTester()
     with pytest.raises(DocumentationError, match=expected_error_message):
         tester.test_schema_section(
-            {"type": "object"},
-            None,
-            OpenAPITestConfig(reference="POST /endpoint > response > nonNullableObject")
+            {"type": "object"}, None, OpenAPITestConfig(reference="POST /endpoint > response > nonNullableObject")
         )
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -235,7 +235,11 @@ def test_null_error():
     tester = SchemaTester()
     with pytest.raises(DocumentationError, match=expected_error_message):
         tester.test_schema_section(
-            {"type": "object"}, None, OpenAPITestConfig(reference="POST /endpoint > response > nonNullableObject")
+            {"type": "object"},
+            None,
+            OpenAPITestConfig(
+                reference="POST /endpoint > response > nonNullableObject"
+            ),
         )
 
 

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -194,8 +194,7 @@ def test_example_schemas(filename):
                 response_handler = ResponseHandlerFactory.create(response)
                 assert sorted(
                     schema_tester.get_response_schema_section(
-                        response_handler,
-                        test_config=OpenAPITestConfig(case_tester=is_pascal_case)
+                        response_handler, test_config=OpenAPITestConfig(case_tester=is_pascal_case)
                     )
                 ) == sorted(schema_section)
 
@@ -206,9 +205,12 @@ def test_validate_response_failure_scenario_with_predefined_data(client):
         assert response.status_code == 200
         assert response.json() == item["expected_response"]
         with pytest.raises(
-                DocumentationError,
-                match='The following property was found in the schema definition, '
-                      'but is missing from the response data: "width"'):
+            DocumentationError,
+            match=(
+                "The following property was found in the schema definition, "
+                'but is missing from the response data: "width"'
+            ),
+        ):
             tester.validate_response(response)
 
 
@@ -469,10 +471,8 @@ def test_nullable_validation():
     for schema in example_schema_types:
         # A null value should always raise an error
         with pytest.raises(
-            DocumentationError, match=VALIDATE_NONE_ERROR.format(
-                    expected=OPENAPI_PYTHON_MAPPING[schema["type"]],
-                    http_message="response"
-                )
+            DocumentationError,
+            match=VALIDATE_NONE_ERROR.format(expected=OPENAPI_PYTHON_MAPPING[schema["type"]], http_message="response"),
         ):
             tester.test_schema_section(schema, None)
 

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -398,7 +398,7 @@ def test_get_request_body_schema_section(pets_post_request: dict[str, Any], pets
     assert schema_section == {
         "type": "object",
         "required": ["name"],
-        "properties": {"name": {"type": "string"}, "tag": {"type": "string"}},
+        "properties": {"name": {"type": ["string", "null"]}, "tag": {"type": "string"}},
     }
 
 

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -194,7 +194,8 @@ def test_example_schemas(filename):
                 response_handler = ResponseHandlerFactory.create(response)
                 assert sorted(
                     schema_tester.get_response_schema_section(
-                        response_handler, test_config=OpenAPITestConfig(case_tester=is_pascal_case)
+                        response_handler,
+                        test_config=OpenAPITestConfig(case_tester=is_pascal_case),
                     )
                 ) == sorted(schema_section)
 
@@ -391,10 +392,14 @@ def test_is_openapi_schema_false():
     assert schema_tester.is_openapi_schema() is False
 
 
-def test_get_request_body_schema_section(pets_post_request: dict[str, Any], pets_api_schema: Path):
+def test_get_request_body_schema_section(
+    pets_post_request: dict[str, Any], pets_api_schema: Path
+):
     test_config = OpenAPITestConfig(case_tester=is_pascal_case)
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
-    schema_section = schema_tester.get_request_body_schema_section(pets_post_request, test_config=test_config)
+    schema_section = schema_tester.get_request_body_schema_section(
+        pets_post_request, test_config=test_config
+    )
     assert schema_section == {
         "type": "object",
         "required": ["name"],
@@ -408,15 +413,21 @@ def test_get_request_body_schema_section_content_type_no_application_json(
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     test_config = OpenAPITestConfig(case_tester=is_pascal_case)
     pets_post_request["CONTENT_TYPE"] = "application/xml"
-    schema_section = schema_tester.get_request_body_schema_section(pets_post_request, test_config=test_config)
+    schema_section = schema_tester.get_request_body_schema_section(
+        pets_post_request, test_config=test_config
+    )
     assert schema_section == {}
 
 
-def test_get_request_body_schema_section_no_content_request(pets_post_request: dict[str, Any], pets_api_schema: Path):
+def test_get_request_body_schema_section_no_content_request(
+    pets_post_request: dict[str, Any], pets_api_schema: Path
+):
     test_config = OpenAPITestConfig(case_tester=is_pascal_case)
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     del pets_post_request["wsgi.input"]
-    schema_section = schema_tester.get_request_body_schema_section(pets_post_request, test_config=test_config)
+    schema_section = schema_tester.get_request_body_schema_section(
+        pets_post_request, test_config=test_config
+    )
     assert schema_section == {}
 
 
@@ -472,7 +483,9 @@ def test_nullable_validation():
         # A null value should always raise an error
         with pytest.raises(
             DocumentationError,
-            match=VALIDATE_NONE_ERROR.format(expected=OPENAPI_PYTHON_MAPPING[schema["type"]], http_message="response"),
+            match=VALIDATE_NONE_ERROR.format(
+                expected=OPENAPI_PYTHON_MAPPING[schema["type"]], http_message="response"
+            ),
         ):
             tester.test_schema_section(schema, None)
 


### PR DESCRIPTION
Currently, the error messages make the debugging hard, as it is difficult to figure out where are there issues (in the request or the documentation), for which request it is happening and what's the exact problem and the expectation.

This PR aims to fix that (partially) by changing a few things:

1. Change how the reference is created: 
The existing reference contained minimal information and it also had a bug where it would continuously attach fields to it, even when it should have pointed to only one field. The new format will contain informations about the request path and type, if it's the request or response, and the drilldowned path to the key with the issues (if it's the case)

The new format will look like this: '`<request_type>` `<request_path>` > `<request/response>` > `<status_code(for responses)>` > `path` > `to` > `key`'

and in practice it could look like this: `GET /api/pets > response > 200 > name > id`

2. Add whenever possible the actual request/response body and the schema section for easy comparison

Update most of the messages to include, besides the new reference, a copy of the actual body and the schema section, along with (hopefully) clearer language as to what went wrong. The combination of these and the new reference should provide enough information to quickly investigate the issue without have to take the request and the documentation and scan for differences side by side.

Examples of how it would look like:

_missing property from the request data_
```
E               openapi_tester.exceptions.DocumentationError: The following property was found in the schema definition, but is missing from the request data: "name"
E               
E               Reference:
E               
E               POST /api/pets > request > name
E               
E               Request body:
E                 {
E                   "tag": "dog"
E               }
E               Schema section:
E                 {
E                   "name": {
E                       "type": "string"
E                   },
E                   "tag": {
E                       "type": "string"
E                   }
E               }
E               
E               Hint: Remove the key from your OpenAPI docs, or include it in your API request
```

_missing property from the response data_
```
E               openapi_tester.exceptions.DocumentationError: The following property was found in the schema definition, but is missing from the response data: "width"
E               
E               Reference:
E               
E               GET /api/v1/cars/incorrect > response > 200 > width
E               
E               Response body:
E                 {
E                   "name": "Saab",
E                   "color": "Yellow",
E                   "height": "Medium height"
E               }
E               Schema section:
E                 {
E                   "name": {
E                       "type": "string",
E                       "maxLength": 254
E                   },
E                   "color": {
E                       "type": "string",
E                       "maxLength": 254
E                   },
E                   "height": {
E                       "type": "string",
E                       "maxLength": 254
E                   },
E                   "width": {
E                       "type": "string",
E                       "maxLength": 254
E                   },
E                   "length": {
E                       "type": "string",
E                       "maxLength": 254
E                   }
E               }
E               
E               Hint: Remove the key from your OpenAPI docs, or include it in your API response
```

Besides all of these, another minor change is to use by default json.dumps on `data` whenever the content is `application/json` in order to reduce verbosity in tests

Additionally Part 3: added support for OAS 3.1 lists of types e.g.:

```
    NewPet:
      type: object
      properties:
        name:
          type:
            - string
            - 'null'
```