### PR TITLE
feat: adding support for Django Ninja test client

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,30 @@ class MySimpleTestCase(SimpleTestCase):
 This will ensure you all newly implemented views will be validated against
 the OpenAPI schema.
 
+
+### Django Ninja Test Client
+
+In case you are using `Django Ninja` and its corresponding [test client](https://github.com/vitalik/django-ninja/blob/master/ninja/testing/client.py#L159), you can use the `OpenAPINinjaClient`, which extends from it, in the same way as the `OpenAPIClient`:
+
+```python
+schema_tester = SchemaTester()
+client = OpenAPINinjaClient(
+        router_or_app=router,
+        schema_tester=schema_tester,
+    )
+response = client.get('/api/v1/tests/123/')
+```
+
+Given that the Django Ninja test client works separately from the django url resolver, you can pass the `path_prefix` argument to the `OpenAPINinjaClient` to specify the prefix of the path that should be used to look into the OpenAPI schema.
+
+```python
+client = OpenAPINinjaClient(
+        router_or_app=router,
+        path_prefix='/api/v1',
+        schema_tester=schema_tester,
+    )
+```
+
 ## Known Issues
 
 * We are using [prance](https://github.com/jfinkhaeuser/prance) as a schema resolver, and it has some issues with the

--- a/openapi_tester/response_handler.py
+++ b/openapi_tester/response_handler.py
@@ -3,14 +3,26 @@ This module contains the concrete response handlers for both DRF and Django Ninj
 """
 
 import json
-from typing import TYPE_CHECKING, Optional, Union
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     from django.http.response import HttpResponse
     from rest_framework.response import Response
 
 
-class ResponseHandler:
+@dataclass
+class GenericRequest:
+    """Generic request class for both DRF and Django Ninja."""
+
+    path: str
+    method: str
+    data: dict = field(default_factory=dict)
+    headers: dict = field(default_factory=dict)
+
+
+class ResponseHandler(ABC):
     """
     This class is used to handle the response and request data
     from both DRF and Django HTTP (Django Ninja) responses.
@@ -24,10 +36,12 @@ class ResponseHandler:
         return self._response
 
     @property
-    def data(self) -> Optional[dict]: ...
+    @abstractmethod
+    def request(self) -> GenericRequest: ...
 
     @property
-    def request_data(self) -> Optional[dict]: ...
+    @abstractmethod
+    def data(self) -> Optional[dict]: ...
 
 
 class DRFResponseHandler(ResponseHandler):
@@ -43,8 +57,13 @@ class DRFResponseHandler(ResponseHandler):
         return self.response.json() if self.response.data is not None else None  # type: ignore[attr-defined]
 
     @property
-    def request_data(self) -> Optional[dict]:
-        return self.response.renderer_context["request"].data  # type: ignore[attr-defined]
+    def request(self) -> GenericRequest:
+        return GenericRequest(
+            path=self.response.renderer_context["request"].path,  # type: ignore[attr-defined]
+            method=self.response.renderer_context["request"].method,  # type: ignore[attr-defined]
+            data=self.response.renderer_context["request"].data,  # type: ignore[attr-defined]
+            headers=self.response.renderer_context["request"].headers,  # type: ignore[attr-defined]
+        )
 
 
 class DjangoNinjaResponseHandler(ResponseHandler):
@@ -52,14 +71,30 @@ class DjangoNinjaResponseHandler(ResponseHandler):
     Handles the response and request data from Django Ninja responses.
     """
 
-    def __init__(self, response: "HttpResponse") -> None:
+    def __init__(
+        self, *request_args, response: "HttpResponse", path_prefix: str = "", **kwargs
+    ) -> None:
         super().__init__(response)
+        self._request_method = request_args[0]
+        self._request_path = f"{path_prefix}{request_args[1]}"
+        self._request_data = self._build_request_data(request_args[2])
+        self._request_headers = kwargs
 
     @property
     def data(self) -> Optional[dict]:
         return self.response.json() if self.response.content else None  # type: ignore[attr-defined]
 
     @property
-    def request_data(self) -> Optional[dict]:
-        response_body = self.response.wsgi_request.body  # type: ignore[attr-defined]
-        return json.loads(response_body) if response_body else None
+    def request(self) -> GenericRequest:
+        return GenericRequest(
+            path=self._request_path,
+            method=self._request_method,
+            data=self._request_data,
+            headers=self._request_headers,
+        )
+
+    def _build_request_data(self, request_data: Any) -> dict:
+        try:
+            return json.loads(request_data)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return {}

--- a/openapi_tester/response_handler_factory.py
+++ b/openapi_tester/response_handler_factory.py
@@ -25,7 +25,9 @@ class ResponseHandlerFactory:
     """
 
     @staticmethod
-    def create(response: Union[Response, "HttpResponse"]) -> "ResponseHandler":
+    def create(
+        *request_args, response: Union[Response, "HttpResponse"], **kwargs
+    ) -> "ResponseHandler":
         if isinstance(response, Response):
-            return DRFResponseHandler(response)
-        return DjangoNinjaResponseHandler(response)
+            return DRFResponseHandler(response=response)
+        return DjangoNinjaResponseHandler(*request_args, response=response, **kwargs)

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -67,3 +67,18 @@ def lazy_combinations(options_list: Sequence[dict[str, Any]]) -> Iterator[dict]:
     for i in range(2, len(options_list) + 1):
         for combination in combinations(options_list, i):
             yield merge_objects(combination)
+
+
+def serialize_json(func):
+    def wrapper(*args, **kwargs):
+        # import pdb; pdb.set_trace()
+        data = kwargs.get("data")
+        content_type = kwargs.get("content_type")
+        if data and content_type == "application/json":
+            try:
+                kwargs["data"] = json.dumps(data)
+            except (TypeError, OverflowError):
+                kwargs["data"] = data
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-contract-tester"
-version = "1.3.2"
+version = "1.4.0"
 description = "Test utility for validating OpenAPI response documentation"
 authors =["Matías Cárdenas <cardenasmatias.1990@gmail.com>", "Sondre Lillebø Gundersen <sondrelg@live.no>", "Na'aman Hirschfeld <nhirschfeld@gmail.com>"]
 license = "BSD-4-Clause"

--- a/test_project/api/serializers.py
+++ b/test_project/api/serializers.py
@@ -9,7 +9,7 @@ class VehicleSerializer(serializers.Serializer):
 
 
 class PetsSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=254, required=False, allow_null=True)
+    name = serializers.CharField(max_length=254, required=True, allow_null=True)
     tag = serializers.CharField(max_length=254, required=False, allow_null=True)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from rest_framework.response import Response
 
+from openapi_tester.response_handler import GenericRequest
 from tests.schema_converter import SchemaToPythonConverter
 from tests.utils import TEST_ROOT
 
@@ -33,32 +34,24 @@ def cars_api_schema() -> Path:
 def pets_post_request():
     request_body = MagicMock()
     request_body.read.return_value = b'{"name": "doggie", "tag": "dog"}'
-    return {
-        "PATH_INFO": "/api/pets",
-        "REQUEST_METHOD": "POST",
-        "SERVER_PORT": "80",
-        "wsgi.url_scheme": "http",
-        "CONTENT_LENGTH": "70",
-        "CONTENT_TYPE": "application/json",
-        "wsgi.input": request_body,
-        "QUERY_STRING": "",
-    }
+    return GenericRequest(
+        method="post",
+        path="/api/pets",
+        data={"name": "doggie", "tag": "dog"},
+        headers={"Content-Type": "application/json"},
+    )
 
 
 @pytest.fixture
 def invalid_pets_post_request():
     request_body = MagicMock()
     request_body.read.return_value = b'{"surname": "doggie", "species": "dog"}'
-    return {
-        "PATH_INFO": "/api/pets",
-        "REQUEST_METHOD": "POST",
-        "SERVER_PORT": "80",
-        "wsgi.url_scheme": "http",
-        "CONTENT_LENGTH": "70",
-        "CONTENT_TYPE": "application/json",
-        "wsgi.input": request_body,
-        "QUERY_STRING": "",
-    }
+    return GenericRequest(
+        method="post",
+        path="/api/pets",
+        data={"surname": "doggie", "species": "dog"},
+        headers={"Content-Type": "application/json"},
+    )
 
 
 @pytest.fixture
@@ -68,20 +61,40 @@ def response_factory() -> Callable:
         url_fragment: str,
         method: str,
         status_code: int | str = 200,
-        response_body: dict | None = None,
+        response_body: str | None = None,
+        request: GenericRequest | None = None,
     ) -> Response:
         converted_schema = None
         if schema:
             converted_schema = SchemaToPythonConverter(deepcopy(schema)).result
         response = Response(status=int(status_code), data=converted_schema)
         response.request = {"REQUEST_METHOD": method, "PATH_INFO": url_fragment}  # type: ignore
+
+        if request:
+            response.renderer_context = {  # type: ignore[attr-defined]
+                "request": MagicMock(
+                    path=request.path,
+                    method=request.method,
+                    data=request.data,
+                    headers=request.headers,
+                )
+            }
+        else:
+            response.renderer_context = {  # type: ignore[attr-defined]
+                "request": MagicMock(
+                    path=url_fragment,
+                    method=method,
+                    data={},
+                    headers={},
+                )
+            }
+
         if schema:
             response.json = lambda: converted_schema  # type: ignore
         elif response_body:
             response.request["CONTENT_LENGTH"] = len(response_body)  # type: ignore
             response.request["CONTENT_TYPE"] = "application/json"  # type: ignore
             response.request["wsgi.input"] = response_body  # type: ignore
-            response.renderer_context = {"request": MagicMock(data=response_body)}  # type: ignore
         return response
 
     return response

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -43,7 +43,9 @@ def test_get_request(cars_api_schema: "Path"):
 
 def test_post_request(openapi_client):
     response = openapi_client.post(
-        path="/api/v1/vehicles", data={"vehicle_type": "suv"}
+        path="/api/v1/vehicles",
+        data={"vehicle_type": "suv"},
+        content_type="application/json",
     )
 
     assert response.status_code == status.HTTP_201_CREATED
@@ -52,7 +54,7 @@ def test_post_request(openapi_client):
 def test_request_validation_is_not_triggered_for_bad_requests(pets_api_schema: "Path"):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
-    response = openapi_client.post(path="/api/pets", data={"name": False})
+    response = openapi_client.post(path="/api/pets", data={})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -64,7 +66,11 @@ def test_request_body_extra_non_documented_field(pets_api_schema: "Path"):
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
 
     with pytest.raises(DocumentationError):
-        openapi_client.post(path="/api/pets", data={"name": "doggie", "age": 1})
+        openapi_client.post(
+            path="/api/pets",
+            data={"name": "doggie", "age": 1},
+            content_type="application/json",
+        )
 
 
 def test_request_body_non_null_fields(pets_api_schema: "Path"):
@@ -72,7 +78,11 @@ def test_request_body_non_null_fields(pets_api_schema: "Path"):
     openapi_client = OpenAPIClient(schema_tester=schema_tester)
 
     with pytest.raises(DocumentationError):
-        openapi_client.post(path="/api/pets", data={"name": "doggie", "tag": None})
+        openapi_client.post(
+            path="/api/pets",
+            data={"name": "doggie", "tag": None},
+            content_type="application/json",
+        )
 
 
 def test_request_multiple_types_supported(pets_api_schema: "Path"):

--- a/tests/test_django_framework.py
+++ b/tests/test_django_framework.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from openapi_tester import SchemaTester
+from openapi_tester.response_handler_factory import ResponseHandlerFactory
 from tests.utils import TEST_ROOT
 
 if TYPE_CHECKING:
@@ -22,7 +23,8 @@ class BaseAPITestCase(APITestCase):
     @staticmethod
     def assertResponse(response: Response, **kwargs) -> None:
         """helper to run validate_response and pass kwargs to it"""
-        schema_tester.validate_response(response=response, **kwargs)
+        response_handler = ResponseHandlerFactory.create(response=response)
+        schema_tester.validate_response(response_handler=response_handler, **kwargs)
 
 
 class PetsAPITests(BaseAPITestCase):

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from openapi_tester import OpenAPIClient, SchemaTester
+from openapi_tester.clients import OpenAPINinjaClient
 from openapi_tester.exceptions import UndocumentedSchemaSectionError
+from test_project.api.ninja.api import router
 from tests.utils import TEST_ROOT
 
 if TYPE_CHECKING:
@@ -18,18 +20,20 @@ def users_ninja_api_schema() -> "Path":
 
 @pytest.fixture
 def client(users_ninja_api_schema: "Path") -> OpenAPIClient:
-    return OpenAPIClient(
-        schema_tester=SchemaTester(schema_file_path=str(users_ninja_api_schema))
+    return OpenAPINinjaClient(
+        router_or_app=router,
+        path_prefix="/ninja_api/users",
+        schema_tester=SchemaTester(schema_file_path=str(users_ninja_api_schema)),
     )
 
 
 def test_get_users(client: OpenAPIClient):
-    response = client.get("/ninja_api/users/")
+    response = client.get("/")
     assert response.status_code == 200
 
 
 def test_get_user(client: OpenAPIClient):
-    response = client.get("/ninja_api/users/1")
+    response = client.get("/1")
     assert response.status_code == 200
 
 
@@ -41,8 +45,8 @@ def test_create_user(client: OpenAPIClient):
         "is_active": True,
     }
     response = client.post(
-        path="/ninja_api/users/",
-        data=payload,
+        path="/",
+        data=json.dumps(payload),
         content_type="application/json",
     )
     assert response.status_code == 201
@@ -56,8 +60,8 @@ def test_update_user(client: OpenAPIClient):
         "is_active": True,
     }
     response = client.put(
-        path="/ninja_api/users/1",
-        data=payload,
+        path="/1",
+        data=json.dumps(payload),
         content_type="application/json",
     )
     assert response.status_code == 200
@@ -65,7 +69,7 @@ def test_update_user(client: OpenAPIClient):
 
 def test_delete_user(client: OpenAPIClient):
     response = client.delete(
-        path="/ninja_api/users/1",
+        path="/1",
     )
     assert response.status_code == 204
 
@@ -76,7 +80,7 @@ def test_patch_user_undocumented_path(client: OpenAPIClient):
     }
     with pytest.raises(UndocumentedSchemaSectionError):
         client.patch(
-            path="/ninja_api/users/1",
+            path="/1",
             data=json.dumps(payload),
             content_type="application/json",
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 from rest_framework.response import Response
 
@@ -23,6 +24,14 @@ def response_factory(
         converted_schema = SchemaToPythonConverter(deepcopy(schema)).result
     response = Response(status=int(status_code), data=converted_schema)
     response.request = {"REQUEST_METHOD": method, "PATH_INFO": url_fragment}  # type: ignore
+    response.renderer_context = {  # type: ignore[attr-defined]
+        "request": MagicMock(
+            path=url_fragment,
+            method=method,
+            data={},
+            headers={},
+        )
+    }
     if schema:
         response.json = lambda: converted_schema  # type: ignore
     return response


### PR DESCRIPTION
### Context

As specified in [Django Ninja documentation](https://django-ninja.dev/guides/testing/), despite being compatible with Django Test Client, using Django Ninja Test Client for Django Ninja APIs ends up being more efficient and faster. Adding therefore support for it in this PR, so that django ninja projects, which already use ninja test client, can switch smoothly to the new client added here.

### Changes

- Adding `OpenAPINinjaClient`, which extends `ninja.testing.TestClient`
- Adding `GenericRequest` class and adapting schema tester to be compatible with both Django a Django Ninja test clients.
- Adding decorator for serializing `json` payloads for Django Test Client, as code was repetitive in each method.