### PR TITLE
fix: making import of ninja optional

### DIFF
--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 import http
+import logging
 from typing import TYPE_CHECKING
 
-# pylint: disable=import-error
-from ninja import NinjaAPI, Router
-from ninja.testing import TestClient
+try:
+    from ninja import NinjaAPI, Router
+    from ninja.testing import TestClient
+except ImportError:
+    NinjaAPI = Router = TestClient = object
+    logging.info("Django-Ninja is not installed.")
+
+
 from rest_framework.test import APIClient
 
+from .exceptions import APIFrameworkNotInstalledError
 from .response_handler_factory import ResponseHandlerFactory
 from .schema_tester import SchemaTester
 from .utils import serialize_json
@@ -129,8 +136,11 @@ class OpenAPINinjaClient(TestClient):
         schema_tester: SchemaTester | None = None,
         **kwargs,
     ) -> None:
-        """Initialize ``OpenAPIClient`` instance."""
-        super().__init__(*args, router_or_app=router_or_app, **kwargs)
+        """Initialize ``OpenAPINinjaClient`` instance."""
+        if not isinstance(object, TestClient):
+            super().__init__(*args, router_or_app=router_or_app, **kwargs)
+        else:
+            raise APIFrameworkNotInstalledError("Django-Ninja is not installed.")
         self.schema_tester = schema_tester or self._schema_tester_factory()
         self._ninja_path_prefix = path_prefix
 

--- a/openapi_tester/exceptions.py
+++ b/openapi_tester/exceptions.py
@@ -34,3 +34,11 @@ class UndocumentedSchemaSectionError(OpenAPISchemaError):
     """
 
     pass
+
+
+class APIFrameworkNotInstalledError(Exception):
+    """
+    Raised when a required API framework is not installed.
+    """
+
+    pass

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -623,11 +623,8 @@ class SchemaTester:
         """
         Verifies that an OpenAPI schema definition matches an API request body.
 
-        :param request: The HTTP request
-        :param case_tester: Optional Callable that checks a string's casing
-        :param ignore_case: Optional list of keys to ignore in case testing
-        :param validators: Optional list of validator functions
-        :param **kwargs: Request keyword arguments
+        :param response_handler: The HTTP response handler (can be a DRF or Ninja response)
+        :param test_config: Optional object with test configuration
         :raises: ``openapi_tester.exceptions.DocumentationError`` for inconsistencies in the API response and schema.
                  ``openapi_tester.exceptions.CaseError`` for case errors.
         """
@@ -660,10 +657,8 @@ class SchemaTester:
         """
         Verifies that an OpenAPI schema definition matches an API response.
 
-        :param response: The HTTP response
-        :param case_tester: Optional Callable that checks a string's casing
-        :param ignore_case: Optional list of keys to ignore in case testing
-        :param validators: Optional list of validator functions
+        :param response_handler: The HTTP response handler (can be a DRF or Ninja response)
+        :param test_config: Optional object with test configuration
         :raises: ``openapi_tester.exceptions.DocumentationError`` for inconsistencies in the API response and schema.
                  ``openapi_tester.exceptions.CaseError`` for case errors.
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from rest_framework.response import Response
 
+import openapi_tester
 from openapi_tester.response_handler import GenericRequest
 from tests.schema_converter import SchemaToPythonConverter
 from tests.utils import TEST_ROOT
@@ -98,3 +99,16 @@ def response_factory() -> Callable:
         return response
 
     return response
+
+
+@pytest.fixture
+def users_ninja_api_schema() -> Path:
+    return TEST_ROOT / "schemas" / "users_django_api_schema.yaml"
+
+
+@pytest.fixture
+def ninja_not_installed():
+    former_client = openapi_tester.clients.TestClient
+    openapi_tester.clients.TestClient = object
+    yield
+    openapi_tester.clients.TestClient = former_client

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -6,8 +6,12 @@ import pytest
 from django.test.testcases import SimpleTestCase
 from rest_framework import status
 
-from openapi_tester.clients import OpenAPIClient
-from openapi_tester.exceptions import DocumentationError, UndocumentedSchemaSectionError
+from openapi_tester.clients import OpenAPIClient, OpenAPINinjaClient
+from openapi_tester.exceptions import (
+    APIFrameworkNotInstalledError,
+    DocumentationError,
+    UndocumentedSchemaSectionError,
+)
 from openapi_tester.schema_tester import SchemaTester
 
 if TYPE_CHECKING:
@@ -29,6 +33,15 @@ def test_init_schema_tester_passed():
     schema_tester = SchemaTester()
 
     client = OpenAPIClient(schema_tester=schema_tester)
+
+    assert client.schema_tester is schema_tester
+
+
+def test_init_schema_tester_passed_ninja():
+    """Ensure passed ``SchemaTester`` instance is used."""
+    schema_tester = SchemaTester()
+
+    client = OpenAPINinjaClient(router_or_app=None, schema_tester=schema_tester)
 
     assert client.schema_tester is schema_tester
 
@@ -162,3 +175,10 @@ def test_django_testcase_client_class(openapi_client_class):
     test_case._pre_setup()
 
     assert isinstance(test_case.client, OpenAPIClient)
+
+
+def test_ninja_not_installed(ninja_not_installed):
+    OpenAPIClient()
+
+    with pytest.raises(APIFrameworkNotInstalledError):
+        OpenAPINinjaClient(router_or_app=None)

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -3,23 +3,17 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from openapi_tester import OpenAPIClient, SchemaTester
+from openapi_tester import SchemaTester
 from openapi_tester.clients import OpenAPINinjaClient
 from openapi_tester.exceptions import UndocumentedSchemaSectionError
 from test_project.api.ninja.api import router
-from tests.utils import TEST_ROOT
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
 @pytest.fixture
-def users_ninja_api_schema() -> "Path":
-    return TEST_ROOT / "schemas" / "users_django_api_schema.yaml"
-
-
-@pytest.fixture
-def client(users_ninja_api_schema: "Path") -> OpenAPIClient:
+def client(users_ninja_api_schema: "Path") -> OpenAPINinjaClient:
     return OpenAPINinjaClient(
         router_or_app=router,
         path_prefix="/ninja_api/users",
@@ -27,17 +21,17 @@ def client(users_ninja_api_schema: "Path") -> OpenAPIClient:
     )
 
 
-def test_get_users(client: OpenAPIClient):
+def test_get_users(client: OpenAPINinjaClient):
     response = client.get("/")
     assert response.status_code == 200
 
 
-def test_get_user(client: OpenAPIClient):
+def test_get_user(client: OpenAPINinjaClient):
     response = client.get("/1")
     assert response.status_code == 200
 
 
-def test_create_user(client: OpenAPIClient):
+def test_create_user(client: OpenAPINinjaClient):
     payload = {
         "name": "John Doe",
         "email": "john.doe@example.com",
@@ -52,7 +46,7 @@ def test_create_user(client: OpenAPIClient):
     assert response.status_code == 201
 
 
-def test_update_user(client: OpenAPIClient):
+def test_update_user(client: OpenAPINinjaClient):
     payload = {
         "name": "John Doe",
         "email": "john.doe@example.com",
@@ -67,14 +61,14 @@ def test_update_user(client: OpenAPIClient):
     assert response.status_code == 200
 
 
-def test_delete_user(client: OpenAPIClient):
+def test_delete_user(client: OpenAPINinjaClient):
     response = client.delete(
         path="/1",
     )
     assert response.status_code == 204
 
 
-def test_patch_user_undocumented_path(client: OpenAPIClient):
+def test_patch_user_undocumented_path(client: OpenAPINinjaClient):
     payload = {
         "name": "John Doe",
     }


### PR DESCRIPTION
As reported by @StopMotionCuber, after we introduced support for Django-Ninja's test client within the module `clients.py`, projects which doesn't have `ninja` installed began failing when attempting to import the former client.

This PR aims to fix this issue while defining an optional import and validation of the `ninja` library.