### PR TITLE
fix: serializing request body when content type not provided

### DIFF
--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -71,10 +71,8 @@ def lazy_combinations(options_list: Sequence[dict[str, Any]]) -> Iterator[dict]:
 
 
 def serialize_json(func):
-    def wrapper(*args, **kwargs):
-        # import pdb; pdb.set_trace()
+    def wrapper(*args, content_type="application/json", **kwargs):
         data = kwargs.get("data")
-        content_type = kwargs.get("content_type")
         if data and content_type == "application/json":
             try:
                 kwargs["data"] = orjson.dumps(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ disable = """
     fixme,
     line-too-long,
     too-many-arguments,
+    too-many-positional-arguments,
 """
 enable = "useless-suppression"
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -64,6 +64,15 @@ def test_post_request(openapi_client):
     assert response.status_code == status.HTTP_201_CREATED
 
 
+def test_post_request_no_content_type(openapi_client):
+    response = openapi_client.post(
+        path="/api/v1/vehicles",
+        data={"vehicle_type": "suv"},
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+
 def test_request_validation_is_not_triggered_for_bad_requests(pets_api_schema: "Path"):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)


### PR DESCRIPTION
As seen in the related issue, when performing a request without specifying the `content-type` as `application/json`, `serialize_json` decorator is skipping the serialization and eventually passing a dict while the framework's function will expect it already formatted as string.

This PR fixes this issue by defaulting `content_type` to `application/json` when it's not provided.