### PR TITLE
fix: validating writeOnly properties only for responses

### DIFF
--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -575,7 +575,7 @@ class SchemaTester:
                     "\n\nHint: Remove the key from your API"
                     f" {test_config.http_message}, or include it in your OpenAPI docs"
                 )
-            if key in write_only_properties:
+            if key in write_only_properties and test_config.http_message == "response":
                 raise DocumentationError(
                     f"{VALIDATE_WRITE_ONLY_RESPONSE_KEY_ERROR.format(write_only_key=key)}\n\nReference:"
                     f"\n\n{test_config.reference} > {key}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-contract-tester"
-version = "1.4.4"
+version = "1.4.5"
 description = "Test utility for validating OpenAPI response documentation"
 authors =["Matías Cárdenas <cardenasmatias.1990@gmail.com>", "Sondre Lillebø Gundersen <sondrelg@live.no>", "Na'aman Hirschfeld <nhirschfeld@gmail.com>"]
 license = "BSD-4-Clause"

--- a/test_project/api/views/pets.py
+++ b/test_project/api/views/pets.py
@@ -13,12 +13,11 @@ if TYPE_CHECKING:
 
 
 class Pet(APIView):
-    def get(self, request: Request, petId: int) -> Response:
+    def get(self, request: Request, petId: int = 0) -> Response:
         pet = {
+            "id": petId if petId else 1,
             "name": "doggie",
-            "category": {"id": 1, "name": "Dogs"},
-            "photoUrls": [],
-            "status": "available",
+            "tag": "Bulldog",
         }
         return Response(pet, HTTP_200_OK)
 

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls.i18n import i18n_patterns
-from django.urls import include, path, re_path
+from django.urls import include, path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
@@ -45,7 +45,6 @@ api_urlpatterns = [
     path("api/<str:version>/router_generated/", include(router.urls)),
     path("api/pets", Pet.as_view(), name="get-pets"),
     path("ninja_api/", ninja_api.urls),
-    re_path(r"api/pet/(?P<petId>\d+)", Pet.as_view(), name="get-pet"),
 ]
 
 internationalised_urlpatterns = i18n_patterns(

--- a/tests/schemas/openapi_v3_reference_schema.yaml
+++ b/tests/schemas/openapi_v3_reference_schema.yaml
@@ -89,12 +89,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /api/pets/{id}:
+  /api/pets/{petId}:
     get:
       description: Returns a user based on a single ID, if the user does not have access to the pet
       operationId: find pet by id
       parameters:
-        - name: id
+        - name: petId
           in: path
           description: ID of pet to fetch
           required: true
@@ -118,7 +118,7 @@ paths:
       description: deletes a single pet based on the ID supplied
       operationId: deletePet
       parameters:
-        - name: id
+        - name: petId
           in: path
           description: ID of pet to delete
           required: true
@@ -158,6 +158,7 @@ components:
             - 'null'
         tag:
           type: string
+          writeOnly: true
 
     Error:
       type: object

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -95,6 +95,28 @@ def test_request_body_extra_non_documented_field(pets_api_schema: "Path"):
         )
 
 
+def test_request_with_write_only_field(pets_api_schema: "Path"):
+    """Ensure validation doesn't raise exception when request a write-only field is
+    included in the request, and not in the response."""
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    openapi_client = OpenAPIClient(schema_tester=schema_tester)
+
+    openapi_client.post(
+        path="/api/pets",
+        data={"name": "doggie", "tag": "Bulldog"},
+        content_type="application/json",
+    )
+
+
+def test_response_with_write_only_field(pets_api_schema: "Path"):
+    """Ensure validation raises exception when response includes a write-only field."""
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    openapi_client = OpenAPIClient(schema_tester=schema_tester)
+
+    with pytest.raises(DocumentationError):
+        openapi_client.get(path="/api/pets")
+
+
 def test_request_body_non_null_fields(pets_api_schema: "Path"):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     openapi_client = OpenAPIClient(schema_tester=schema_tester)

--- a/tests/test_django_framework.py
+++ b/tests/test_django_framework.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from openapi_tester import SchemaTester
+from openapi_tester.exceptions import DocumentationError
 from openapi_tester.response_handler_factory import ResponseHandlerFactory
 from tests.utils import TEST_ROOT
 
@@ -13,7 +15,7 @@ if TYPE_CHECKING:
     from rest_framework.response import Response
 
 schema_tester = SchemaTester(
-    schema_file_path=str(TEST_ROOT) + "/schemas/sample-schemas/content_types.yaml"
+    schema_file_path=str(TEST_ROOT) + "/schemas/openapi_v3_reference_schema.yaml"
 )
 
 
@@ -30,13 +32,9 @@ class BaseAPITestCase(APITestCase):
 class PetsAPITests(BaseAPITestCase):
     def test_get_pet_by_id(self):
         response = self.client.get(
-            reverse(
-                "get-pet",
-                kwargs={
-                    "petId": 1,
-                },
-            ),
+            reverse("get-pets"),
             content_type="application/vnd.api+json",
         )
         assert response.status_code == 200
-        self.assertResponse(response)
+        with pytest.raises(DocumentationError):
+            self.assertResponse(response)

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -125,6 +125,10 @@ docs_any_of_example = {
         },
     ],
 }
+# Excluded schemas files for test_example_schemas as they include expected validation errors.
+EXCLUDED_SCHEMA_FILES = [
+    "openapi_v3_reference_schema.yaml",
+]
 
 
 def test_loader_inference(settings):
@@ -172,7 +176,9 @@ def test_drf_coerced_model_primary_key(client, url):
     [
         filename
         for filename in glob.iglob(str(TEST_ROOT) + "/schemas/**/**", recursive=True)
-        if os.path.isfile(filename) and "metadata" not in filename
+        if os.path.isfile(filename)
+        and "metadata" not in filename
+        and filename.split("/")[-1] not in EXCLUDED_SCHEMA_FILES
     ],
 )
 def test_example_schemas(filename):
@@ -403,7 +409,10 @@ def test_get_request_body_schema_section(
     assert schema_section == {
         "type": "object",
         "required": ["name"],
-        "properties": {"name": {"type": ["string", "null"]}, "tag": {"type": "string"}},
+        "properties": {
+            "name": {"type": ["string", "null"]},
+            "tag": {"type": "string", "writeOnly": True},
+        },
     }
 
 
@@ -745,7 +754,7 @@ def test_get_paths_object_no_path_prefix(pets_api_schema: Path):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
     paths_object = schema_tester.get_paths_object()
 
-    assert list(paths_object.keys()) == ["/api/pets", "/api/pets/{id}"]
+    assert list(paths_object.keys()) == ["/api/pets", "/api/pets/{petId}"]
 
 
 def test_get_paths_object_path_prefix(pets_api_schema_prefix_in_server: Path):


### PR DESCRIPTION
Validation of `writeOnly` properties is currently being applied for both requests and responses, being the later naturally wrong. When submitting both a request and a response share an object on the OpenAPI documentation, which have this `writeOnly` defined for a field, one get the following error on the request (as also seen in the example in the linked issue to this PR):

```
openapi_tester.exceptions.DocumentationError: The following property was found in the response, but is documented as being "writeOnly": "tag"
```

The validation should happen only for requests. This PR makes sure of so, adding an additional condition and additional tests for it