### PR TITLE
feat: readonly fields validation for requests

### DIFF
--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -50,6 +50,7 @@ VALIDATE_EXCESS_KEY_ERROR = (
     'but is missing from the schema definition: "{excess_key}"'
 )
 VALIDATE_WRITE_ONLY_RESPONSE_KEY_ERROR = 'The following property was found in the response, but is documented as being "writeOnly": "{write_only_key}"'
+VALIDATE_READ_ONLY_RESPONSE_KEY_ERROR = 'The following property was found in the request, but is documented as being "readOnly": "{read_only_key}"'
 VALIDATE_ONE_OF_ERROR = "Expected data to match one and only one of the oneOf schema types; found {matches} matches"
 VALIDATE_ANY_OF_ERROR = "Expected data to match one or more of the documented anyOf schema types, but found no matches"
 UNDOCUMENTED_SCHEMA_SECTION_ERROR = (

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -81,3 +81,24 @@ def serialize_json(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def get_required_keys(
+    schema_section: dict,
+    http_message: str,
+    write_only_props: list[str],
+    read_only_props: list[str],
+) -> list[str]:
+    if http_message == "request":
+        return [
+            key
+            for key in schema_section.get("required", [])
+            if key not in read_only_props
+        ]
+    if http_message == "response":
+        return [
+            key
+            for key in schema_section.get("required", [])
+            if key not in write_only_props
+        ]
+    return []

--- a/tests/schemas/openapi_v3_reference_schema.yaml
+++ b/tests/schemas/openapi_v3_reference_schema.yaml
@@ -146,6 +146,7 @@ components:
             id:
               type: integer
               format: int64
+              readOnly: true
 
     NewPet:
       type: object

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -108,6 +108,20 @@ def test_request_with_write_only_field(pets_api_schema: "Path"):
     )
 
 
+def test_request_with_read_only_field(pets_api_schema: "Path"):
+    """Ensure validation doesn't raise exception when request a write-only field is
+    included in the request, and not in the response."""
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    openapi_client = OpenAPIClient(schema_tester=schema_tester)
+
+    with pytest.raises(DocumentationError):
+        openapi_client.post(
+            path="/api/pets",
+            data={"id": 1, "name": "doggie", "tag": "Bulldog"},
+            content_type="application/json",
+        )
+
+
 def test_response_with_write_only_field(pets_api_schema: "Path"):
     """Ensure validation raises exception when response includes a write-only field."""
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,8 @@
-from openapi_tester.utils import merge_objects, serialize_schema_section_data
+from openapi_tester.utils import (
+    get_required_keys,
+    merge_objects,
+    serialize_schema_section_data,
+)
 from tests.utils import sort_object
 
 object_1 = {
@@ -61,3 +65,75 @@ def test_serialize_schema_section_data():
         "  }"
         "\n}"
     )
+
+
+def test_get_required_keys():
+    # given
+    schema_section = {
+        "type": "object",
+        "required": ["key1", "key2"],
+        "properties": {"key1": {"type": "string"}, "key2": {"type": "string"}},
+    }
+    read_only_props = []
+    write_only_props = []
+    http_message = "response"
+
+    # when
+    required_keys = get_required_keys(
+        schema_section=schema_section,
+        http_message=http_message,
+        read_only_props=read_only_props,
+        write_only_props=write_only_props,
+    )
+
+    # then
+    assert required_keys == ["key1", "key2"]
+
+
+def test_get_required_keys_request_with_read_only_field():
+    # given
+    schema_section = {
+        "type": "object",
+        "required": ["key1", "key2"],
+        "properties": {"key1": {"type": "string"}, "key2": {"type": "string"}},
+        "readOnly": ["key2"],
+    }
+    read_only_props = ["key2"]
+    write_only_props = []
+
+    http_message = "request"
+
+    # when
+    required_keys = get_required_keys(
+        schema_section=schema_section,
+        http_message=http_message,
+        read_only_props=read_only_props,
+        write_only_props=write_only_props,
+    )
+
+    # then
+    assert required_keys == ["key1"]
+
+
+def test_get_required_keys_response_with_write_only_field():
+    # given
+    schema_section = {
+        "type": "object",
+        "required": ["key1", "key2"],
+        "properties": {"key1": {"type": "string"}, "key2": {"type": "string"}},
+        "writeOnly": ["key2"],
+    }
+    write_only_props = ["key2"]
+    read_only_props = []
+    http_message = "response"
+
+    # when
+    required_keys = get_required_keys(
+        schema_section=schema_section,
+        http_message=http_message,
+        write_only_props=write_only_props,
+        read_only_props=read_only_props,
+    )
+
+    # then
+    assert required_keys == ["key1"]


### PR DESCRIPTION
Adding validation for requests which include a `readOnly` field.