### PR TITLE
chore: removing unnecesary log when django-ninja is not installed

### DIFF
--- a/openapi_tester/clients.py
+++ b/openapi_tester/clients.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import http
-import logging
 from typing import TYPE_CHECKING
 
 try:
@@ -11,7 +10,6 @@ try:
     from ninja.testing import TestClient
 except ImportError:
     NinjaAPI = Router = TestClient = object
-    logging.info("Django-Ninja is not installed.")
 
 
 from rest_framework.test import APIClient


### PR DESCRIPTION
The optional import of `django-ninja` is there because it's not mandatory to have it installed to have the package, as one could use it with DRF. However, it's not necessary to have a log entry informing this, given this is already logged when attempting to create an instance of `OpenAPINinjaClient`.  

This PR handles the previous described situation, by removing the log entry.