### PR TITLE
fix: updating artifact actions versions as v3 was deprecated

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8.14" , "3.9.14", "3.10.7", "3.11.2" ]
-        django-version: [ "3.2", "4.0", "4.1", "5.0" ]
+        python-version: ["3.8.14", "3.9.14", "3.10.7", "3.11.2"]
+        django-version: ["3.2", "4.0", "4.1", "5.0"]
         exclude:
           - django-version: 3.2
             python-version: 3.11.2
@@ -73,7 +73,7 @@ jobs:
           coverage run -m pytest
           coverage xml
           coverage report
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
           path: coverage.xml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-xml
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Updating artifacts actions - See: https://github.com/orgs/community/discussions/142581