### PR TITLE
feat: adding validation for int32 and int64 format in integer types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --fix ]
+        args: [--fix]
       # Run the formatter.
       - id: ruff-format
 
@@ -24,10 +24,10 @@ repos:
     rev: v3.8.0
     hooks:
       - id: pyupgrade
-        args: [ "--py3-plus", "--py36-plus", "--py37-plus" ]
+        args: ["--py3-plus", "--py36-plus", "--py37-plus"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         additional_dependencies:
@@ -45,8 +45,8 @@ repos:
         name: pylint
         entry: pylint
         language: python
-        types: [ python ]
-        args: [ "--extension-pkg-allow-list=orjson"]
+        types: [python]
+        args: ["--extension-pkg-allow-list=orjson"]
         exclude: tests|test_project|manage.py
         additional_dependencies:
           - django

--- a/openapi_tester/response_handler.py
+++ b/openapi_tester/response_handler.py
@@ -2,11 +2,10 @@
 This module contains the concrete response handlers for both DRF and Django Ninja responses.
 """
 
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional, Union
-
-import orjson
 
 if TYPE_CHECKING:
     from django.http.response import HttpResponse
@@ -96,6 +95,6 @@ class DjangoNinjaResponseHandler(ResponseHandler):
 
     def _build_request_data(self, request_data: Any) -> dict:
         try:
-            return orjson.loads(request_data)
-        except (orjson.JSONDecodeError, TypeError, ValueError):
+            return json.loads(request_data)
+        except (json.JSONDecodeError, TypeError, ValueError):
             return {}

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -656,7 +656,6 @@ class SchemaTester:
             request_body_schema = self.get_request_body_schema_section(
                 response_handler.request, test_config=test_config
             )
-
             if request_body_schema:
                 self.test_schema_section(
                     schema_section=request_body_schema,

--- a/openapi_tester/validators.py
+++ b/openapi_tester/validators.py
@@ -62,6 +62,14 @@ base64_format_validator = create_validator(
     lambda x: base64.b64encode(base64.b64decode(x, validate=True)) == x
 )
 
+int32_format_validator = create_validator(
+    lambda x: isinstance(x, int) and x.bit_length() <= 32, True
+)
+
+int64_format_validator = create_validator(
+    lambda x: isinstance(x, int) and x.bit_length() <= 64, True
+)
+
 VALIDATOR_MAP: dict[str, Callable] = {
     # by type
     "string": create_validator(lambda x: isinstance(x, str), True),
@@ -83,6 +91,8 @@ VALIDATOR_MAP: dict[str, Callable] = {
     "double": number_format_validator,
     "email": create_validator(EmailValidator()),
     "float": number_format_validator,
+    "int32": int32_format_validator,
+    "int64": int64_format_validator,
     "ipv4": create_validator(validate_ipv4_address),
     "ipv6": create_validator(validate_ipv6_address),
     "time": create_validator(parse_time, True),

--- a/test_project/api/ninja/api.py
+++ b/test_project/api/ninja/api.py
@@ -22,13 +22,24 @@ def create_user(request, user: UserIn):
 
 @router.get("/{user_id}", response={200: UserOut})
 def get_user(request, user_id: int):
-    return {
-        "id": 1,
-        "name": "John Doe",
-        "email": "john.doe@example.com",
-        "age": 30,
-        "is_active": True,
-    }
+    if user_id == 1:
+        return {
+            "id": 1,
+            "name": "John Doe",
+            "email": "john.doe@example.com",
+            "age": 30,
+            "is_active": True,
+        }
+    else:
+        return {
+            "id": 2,
+            "name": "Jane Doe",
+            "email": "jane.doe@example.com",
+            "age": 25,
+            "is_active": True,
+            "total_points_earned": 2**64,
+            "membership_level": 3,
+        }
 
 
 @router.put("/{user_id}", response={200: UserOut})

--- a/test_project/api/ninja/schemas.py
+++ b/test_project/api/ninja/schemas.py
@@ -6,6 +6,8 @@ class UserIn(Schema):
     email: str
     age: int
     is_active: bool
+    membership_level: int = 0
+    total_points_earned: int = 0
 
     class Config:
         example = {
@@ -13,6 +15,8 @@ class UserIn(Schema):
             "email": "john.doe@example.com",
             "age": 30,
             "is_active": True,
+            "membership_level": 3,
+            "total_points_earned": 1000,
         }
 
 
@@ -26,4 +30,6 @@ class UserOut(UserIn):
             "email": "john.doe@example.com",
             "age": 30,
             "is_active": True,
+            "membership_level": 3,
+            "total_points_earned": 1000,
         }

--- a/test_project/migrations/0001_initial.py
+++ b/test_project/migrations/0001_initial.py
@@ -5,10 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    initial = True
-
-    dependencies: list[tuple[str, str]] = []
-
     operations = [
         migrations.CreateModel(
             name="Names",

--- a/tests/schemas/sample-schemas/observations.yaml
+++ b/tests/schemas/sample-schemas/observations.yaml
@@ -43,10 +43,10 @@ info:
     (eg. trasferimenti, disallineamenti dovuti alla durata temporale dei
     campionamenti, errori umani, ...).
 servers:
-- url: https://localhost/covid-19/v1
-  description: |-
-    development server
-  x-sandbox: true
+  - url: https://localhost/covid-19/v1
+    description: |-
+      development server
+    x-sandbox: true
 tags:
   - name: data
     description: Returns data.
@@ -55,16 +55,15 @@ tags:
 x-commons:
   common-responses: &common-responses
     default:
-      $ref: '#/components/responses/default'
+      $ref: "#/components/responses/default"
     "429":
-      $ref: '#/components/responses/429'
+      $ref: "#/components/responses/429"
     "503":
-      $ref: '#/components/responses/503'
-
+      $ref: "#/components/responses/503"
 
 paths:
-  /observations/administrative-units/{administrative_unit}/{administrative_unit_id}:
-    get:
+  ? /observations/administrative-units/{administrative_unit}/{administrative_unit_id}
+  : get:
       tags:
         - data
       description: |-
@@ -92,71 +91,71 @@ paths:
         endpoint destinati a profili pubblici.
       operationId: observations.get_administrative_unit_data
       parameters:
-      - $ref: '#/components/parameters/AcceptLanguage'
-      - name: administrative_unit
-        description: |-
-          The type of administrative unit, related to the
-          https://github.com/italia/daf-ontologie-vocabolari-controllati/tree/master/VocabolariControllati/territorial-classifications
-          vocabulary, in italian.
-        schema:
-          type: string
-          enum:
-          - regioni
-          - comuni
-          - province
-          example: regioni
-        in: path
-        required: true
-      - name: administrative_unit_id
-        description: |-
-          Administrative units use the Istat identifier.
-        schema:
-          type: string
-        examples:
-          Umbria:
-            summary: Umbria
-            value: 10
-        in: path
-        required: true
-      - name: metadata
-        in: query
-        description: |-
-          Include Observations metadata in the `_meta` property. This includes
-          administrative_unit information.
-        schema:
-          type: boolean
-          default: false
-      - name: recurse
-        in: query
-        description: |-
-          Returns observations from sub-administration units, eg. provinces and cities.
-          This feature can be disabled or delegated to another endpoint.
-          Json responses are enveloped in an object supporting the return of multiple datasets.
-        schema:
-          type: boolean
-          default: false
-      - name: embed
-        schema:
-          type: string
-        in: query
-      - name: phenomenon_time_start
-        in: query
-        schema:
-          $ref: '#/components/schemas/Temporal'
-      - name: phenomenon_time_end
-        in: query
-        schema:
-          $ref: '#/components/schemas/Temporal'
-      - name: parameter_ids
-        in: query
-        schema:
-          type: array
-          items:
-            $ref: '#/components/schemas/ObservationParameterId'
+        - $ref: "#/components/parameters/AcceptLanguage"
+        - name: administrative_unit
+          description: |-
+            The type of administrative unit, related to the
+            https://github.com/italia/daf-ontologie-vocabolari-controllati/tree/master/VocabolariControllati/territorial-classifications
+            vocabulary, in italian.
+          schema:
+            type: string
+            enum:
+              - regioni
+              - comuni
+              - province
+            example: regioni
+          in: path
+          required: true
+        - name: administrative_unit_id
+          description: |-
+            Administrative units use the Istat identifier.
+          schema:
+            type: string
+          examples:
+            Umbria:
+              summary: Umbria
+              value: 10
+          in: path
+          required: true
+        - name: metadata
+          in: query
+          description: |-
+            Include Observations metadata in the `_meta` property. This includes
+            administrative_unit information.
+          schema:
+            type: boolean
+            default: false
+        - name: recurse
+          in: query
+          description: |-
+            Returns observations from sub-administration units, eg. provinces and cities.
+            This feature can be disabled or delegated to another endpoint.
+            Json responses are enveloped in an object supporting the return of multiple datasets.
+          schema:
+            type: boolean
+            default: false
+        - name: embed
+          schema:
+            type: string
+          in: query
+        - name: phenomenon_time_start
+          in: query
+          schema:
+            $ref: "#/components/schemas/Temporal"
+        - name: phenomenon_time_end
+          in: query
+          schema:
+            $ref: "#/components/schemas/Temporal"
+        - name: parameter_ids
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/ObservationParameterId"
       responses:
         <<: *common-responses
-        '200':
-          $ref: '#/components/responses/AdministrativeUnitDatasets'
+        "200":
+          $ref: "#/components/responses/AdministrativeUnitDatasets"
 
   /observation-parameters/{parameter_id}:
     get:
@@ -166,36 +165,34 @@ paths:
       tags:
         - metadata
       parameters:
-      - $ref: '#/components/parameters/AcceptLanguage'
-      - name: parameter_id
-        schema:
-          $ref: '#/components/schemas/ObservationParameterId'
-        in: path
-        required: true
+        - $ref: "#/components/parameters/AcceptLanguage"
+        - name: parameter_id
+          schema:
+            $ref: "#/components/schemas/ObservationParameterId"
+          in: path
+          required: true
       responses:
         <<: *common-responses
         "200":
-           description: Returns the information on a parameter.
-           content:
-             application/json:
-               schema:
-                 $ref: '#/components/schemas/ObservationParameter'
-
+          description: Returns the information on a parameter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ObservationParameter"
 
 components:
-
   examples:
     AdministrativeUnit:
       summary: Una unità amministrativa
       value: &AdministrativeUnitPerugia
         country_id: ITA
         country_name: Italia
-        region_id: '10'
+        region_id: "10"
         region_name: Umbria
-        province_id: '054'
+        province_id: "054"
         province_name: Perugia
         province_acronym: PG
-        city_id: '054039'
+        city_id: "054039"
         city_name: Perugia
     # CSV
     OsservazioniComuneAllCSV:
@@ -203,7 +200,7 @@ components:
       description: Dati di un comune con tutti i campi possibili
       value: "
         phenomenon_time,administrative_unit,administrative_unit_id,\
-          positive_cases_with_date,in_intensive_care,cumulative_hospitalized,cumulative_positives,isolamento_domiciliare,variazione_totale_positivi,nuovi_positivi,dimessi_guariti,deceduti,totale_casi,tamponi,casi_testati\n
+        positive_cases_with_date,in_intensive_care,cumulative_hospitalized,cumulative_positives,isolamento_domiciliare,variazione_totale_positivi,nuovi_positivi,dimessi_guariti,deceduti,totale_casi,tamponi,casi_testati\n
         2020-05-26,comune,054039,231,9,240,1369,1609,-62,4,1132,366,3107,48903,34428\n
         "
     ObservationsRegionCSV:
@@ -218,9 +215,9 @@ components:
       summary: Dati di un comune
       value: "\n
         phenomenon_time,administrative_unit,administrative_unit_id,positive_cases_with_date,in_intensive_care,\
-          region_id,region_name,\
-          province_id,province_name,\
-          city_id,city_name\n
+        region_id,region_name,\
+        province_id,province_name,\
+        city_id,city_name\n
         2020-05-20,comune,054039, 10, 4,10,Umbria,054,Perugia,054039,Perugia\n
         2020-05-21,comune,054039, 11, 3,10,Umbria,054,Perugia,054039,Perugia\n
         2020-05-22,comune,054039,  8, 5,10,Umbria,054,Perugia,054039,Perugia\n
@@ -240,11 +237,11 @@ components:
         value_measurement_unit: people
         _embedded:
           parameter:
-              '@id': https://w3id.org/italia/data/observation-parameter/positive_cases_with_date
-              name: casi sintomatici con data inizio sintomi
+            "@id": https://w3id.org/italia/data/observation-parameter/positive_cases_with_date
+            name: casi sintomatici con data inizio sintomi
           feature_of_interest:
             name: Paziente
-            '@id': https://w3id.org/italia/data/feature-of-interest/patient
+            "@id": https://w3id.org/italia/data/feature-of-interest/patient
     ObservationsRegion:
       summary: Osservazioni su una singola unità amministrativa.
       value: &ObservationsRegion
@@ -256,26 +253,26 @@ components:
             description: Regione Umbria
             url: https://www.indicepa.gov.it/ricerca/n-dettaglioservfe.php?cod_amm=r_umbria
         items:
-        - value: 4
-          parameter_id: in_intensive_care
-          phenomenon_time: "2020-05-20"
-        - value: 3
-          parameter_id: in_intensive_care
-          phenomenon_time: "2020-05-21"
-          modified: "2020-05-21"
-        - value: 5
-          parameter_id: in_intensive_care
-          phenomenon_time: "2020-05-20"
-        - value: 11
-          parameter_id: positive_cases_with_date
-          phenomenon_time: "2020-05-21"
-          modified: "2020-05-21"
-        - value: 8
-          parameter: positive_cases_with_date
-          generation_time: "2020-05-22"
-          phenomenon_time: "2020-05-22"
-          modified: "2020-05-22"
-        - <<: *ObservationLong
+          - value: 4
+            parameter_id: in_intensive_care
+            phenomenon_time: "2020-05-20"
+          - value: 3
+            parameter_id: in_intensive_care
+            phenomenon_time: "2020-05-21"
+            modified: "2020-05-21"
+          - value: 5
+            parameter_id: in_intensive_care
+            phenomenon_time: "2020-05-20"
+          - value: 11
+            parameter_id: positive_cases_with_date
+            phenomenon_time: "2020-05-21"
+            modified: "2020-05-21"
+          - value: 8
+            parameter: positive_cases_with_date
+            generation_time: "2020-05-22"
+            phenomenon_time: "2020-05-22"
+            modified: "2020-05-22"
+          - <<: *ObservationLong
     DatasetRegion:
       summary: Il dataset di una regione.
       value: &DatasetRegion
@@ -283,7 +280,7 @@ components:
           - <<: *ObservationsRegion
     # GeoJson
     GeoUmbria: &GeoUmbria
-      description:  https://ioggstream.github.io/api-confini-amministrativi/2020-01-01/generalizzata/comune/002082.geojson
+      description: https://ioggstream.github.io/api-confini-amministrativi/2020-01-01/generalizzata/comune/002082.geojson
       summary: A geojson region
       value:
         type: "Feature"
@@ -296,7 +293,7 @@ components:
       value:
         <<: *GeoUmbria
         properties:
-          $ref: '#/components/examples/ObservationsRegion/value'
+          $ref: "#/components/examples/ObservationsRegion/value"
     ObservationsRegionGeo:
       summary: geojson embedded
       value: &ObservationsRegionGeo
@@ -312,33 +309,33 @@ components:
           - <<: *ObservationsRegionGeo
   responses:
     "429":
-      $ref: 'https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml#/responses/429TooManyRequests'
+      $ref: "https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml#/responses/429TooManyRequests"
     "503":
-      $ref: 'https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml#/responses/503ServiceUnavailable'
+      $ref: "https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml#/responses/503ServiceUnavailable"
     default:
-      $ref: 'https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml#/responses/default'
+      $ref: "https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml#/responses/default"
     AdministrativeUnitDatasets:
       description: |-
         Elenca delle collezioni di osservazioni
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ObservationDataset'
+            $ref: "#/components/schemas/ObservationDataset"
           examples:
             Regione:
-              $ref: '#/components/examples/DatasetRegion'
+              $ref: "#/components/examples/DatasetRegion"
         text/csv:
           examples:
             ComuneCSV:
-              $ref: '#/components/examples/ObservationsCityCSV'
+              $ref: "#/components/examples/ObservationsCityCSV"
             RegioneCSV:
-              $ref: '#/components/examples/ObservationsRegionCSV'
+              $ref: "#/components/examples/ObservationsRegionCSV"
         application/geo+json:
           schema:
-            $ref: '#/components/schemas/GeoJsonData'
+            $ref: "#/components/schemas/GeoJsonData"
           examples:
             FeatureCollection:
-              $ref: '#/components/examples/FeatureCollection'
+              $ref: "#/components/examples/FeatureCollection"
   parameters:
     AcceptLanguage:
       description: |-
@@ -347,20 +344,20 @@ components:
         that are allowed.
       in: header
       schema:
-        $ref: '#/components/schemas/Language'
+        $ref: "#/components/schemas/Language"
       name: Accept-Language
       example: "it"
   schemas:
     GeoJsonFeature:
-      $ref: 'https://geojson.org/schema/Feature.json'
+      $ref: "https://geojson.org/schema/Feature.json"
     GeoJsonData:
       allOf:
-        - $ref: '#/components/schemas/GeoJsonFeature'
+        - $ref: "#/components/schemas/GeoJsonFeature"
         - properties:
             properties:
-              $ref: '#/components/schemas/Observations'
+              $ref: "#/components/schemas/Observations"
       example:
-        $ref: '#/components/examples/ObservationGeo'
+        $ref: "#/components/examples/ObservationGeo"
     Observations:
       description: |-
         This is a collection of observations, together with metadata useful
@@ -369,11 +366,11 @@ components:
         For the AdministrativeUnit, metadata include locality information
       properties:
         _meta:
-          $ref: '#/components/schemas/Metadata'
+          $ref: "#/components/schemas/Metadata"
         items:
           type: array
           items:
-            $ref: '#/components/schemas/Observation'
+            $ref: "#/components/schemas/Observation"
     ObservationDataset:
       description: |-
         An ObservationDataset contains a list of Observations: one for
@@ -382,17 +379,17 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/Observations'
+            $ref: "#/components/schemas/Observations"
     Metadata:
       description: |-
         Metadata associated to a given observation collection.
       properties:
         administrative_unit:
-          $ref: '#/components/schemas/AdministrativeUnit'
+          $ref: "#/components/schemas/AdministrativeUnit"
         phenomenon_time_start:
-          $ref: '#/components/schemas/Temporal'
+          $ref: "#/components/schemas/Temporal"
         phenomenon_time_end:
-          $ref: '#/components/schemas/Temporal'
+          $ref: "#/components/schemas/Temporal"
         source:
           type: string
           format: uri
@@ -408,9 +405,22 @@ components:
     ObservationParameterId:
       type: string
       description: A short string representing the parameter in a given namespace
-      enum: [positive_cases_with_date, hospitalized-with-symptoms,in_intensive_care,totale_ospedalizzati,
-             isolamento_domiciliare,totale_positivi,variazione_totale_positivi,nuovi_positivi,dimessi_guariti,
-             deceduti,totale_casi,tamponi,casi_testati]
+      enum:
+        [
+          positive_cases_with_date,
+          hospitalized-with-symptoms,
+          in_intensive_care,
+          totale_ospedalizzati,
+          isolamento_domiciliare,
+          totale_positivi,
+          variazione_totale_positivi,
+          nuovi_positivi,
+          dimessi_guariti,
+          deceduti,
+          totale_casi,
+          tamponi,
+          casi_testati,
+        ]
     ObservationParameter:
       x-describedby: https://w3id.org/italia/onto/IoT/ObservationParameter
       description: |-
@@ -422,7 +432,7 @@ components:
           type: string
           format: url
         id:
-          $ref: '#/components/schemas/ObservationParameterId'
+          $ref: "#/components/schemas/ObservationParameterId"
         name:
           type: string
           description: |-
@@ -441,8 +451,8 @@ components:
       description: >-
         Allowed language codes.
       enum:
-      - it
-      - en
+        - it
+        - en
       type: string
     Observation:
       type: object
@@ -474,19 +484,19 @@ components:
            '@id': https://w3id.org/italia/data/feature-of-interest/patient
         ```
       required:
-      - parameter_id
-      - value
-      - phenomenon_time
+        - parameter_id
+        - value
+        - phenomenon_time
       properties:
         uuid:
           type: string
           format: url
         phenomenon_time:
-          $ref: '#/components/schemas/Temporal'
+          $ref: "#/components/schemas/Temporal"
         modified:
-          $ref: '#/components/schemas/Temporal'
+          $ref: "#/components/schemas/Temporal"
         generation_time:
-          $ref: '#/components/schemas/Temporal'
+          $ref: "#/components/schemas/Temporal"
         feature_of_interest_id:
           type: string
           description: |-
@@ -494,11 +504,11 @@ components:
         parameter_id:
           type: string
         value:
-          type: number
+          type: integer
           format: int64
           example: 10
         value_measurement_unit:
-          $ref: '#/components/schemas/MeasurementUnit'
+          $ref: "#/components/schemas/MeasurementUnit"
       example:
         phenomenon_time: 2020-05-26
         parameter_id: positive_cases_with_date
@@ -507,18 +517,18 @@ components:
         value_measurement_unit: units
         _embedded:
           parameter:
-              '@id': https://w3id.org/italia/data/observation-parameter/positive_cases_with_date
-              name: casi sintomatici con data inizio sintomi
+            "@id": https://w3id.org/italia/data/observation-parameter/positive_cases_with_date
+            name: casi sintomatici con data inizio sintomi
           feature_of_interest:
-              '@id': https://w3id.org/italia/data/observation-parameter/positive_cases_with_date
-              name: casi sintomatici con data inizio sintomi
+            "@id": https://w3id.org/italia/data/observation-parameter/positive_cases_with_date
+            name: casi sintomatici con data inizio sintomi
     MeasurementUnit:
       x-describedby: https://w3id.org/italia/data/measurement-unit
       type: string
       enum:
-      - meter
-      - units
-      - people
+        - meter
+        - units
+        - people
       description: |-
         See https://w3id.org/italia/data/measurement-unit for a vocabulary
         This is work-in-progress!
@@ -529,12 +539,12 @@ components:
       example: &AdministrativeUnitExample
         country_id: ITA
         country_name: Italia
-        region_id: '10'
+        region_id: "10"
         region_name: Umbria
-        province_id: '054'
+        province_id: "054"
         province_name: Perugia
         province_acronym: PG
-        city_id: '054039'
+        city_id: "054039"
         city_name: Perugia
       required:
         - country_id

--- a/tests/schemas/users_django_api_schema.yaml
+++ b/tests/schemas/users_django_api_schema.yaml
@@ -1,7 +1,7 @@
-openapi:  3.0.0
+openapi: 3.0.0
 info:
   title: My API
-  version:  1.0.0
+  version: 1.0.0
 paths:
   /ninja_api/users/:
     post:
@@ -10,43 +10,43 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserIn'
+              $ref: "#/components/schemas/UserIn"
             examples:
               example1:
                 summary: Example payload for creating a user
                 value:
                   name: John Doe
                   email: john.doe@example.com
-                  age:  30
+                  age: 30
                   is_active: true
         required: true
       responses:
-        '201':
+        "201":
           description: User created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserOut'
+                $ref: "#/components/schemas/UserOut"
               examples:
                 example1:
                   summary: Example response for a newly created user
                   value:
-                    id:  1
+                    id: 1
                     name: John Doe
                     email: john.doe@example.com
-                    age:  30
+                    age: 30
                     is_active: true
     get:
       summary: Get all users
       responses:
-        '200':
+        "200":
           description: All users retrieved successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UserOut'
+                  $ref: "#/components/schemas/UserOut"
               examples:
                 example1:
                   summary: Example response for all users
@@ -71,20 +71,20 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: User retrieved successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserOut'
+                $ref: "#/components/schemas/UserOut"
               examples:
                 example1:
                   summary: Example response for a specific user
                   value:
-                    id:  1
+                    id: 1
                     name: John Doe
                     email: john.doe@example.com
-                    age:  30
+                    age: 30
                     is_active: true
     put:
       summary: Update a specific user by ID
@@ -98,31 +98,33 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserIn'
+              $ref: "#/components/schemas/UserIn"
             examples:
               example1:
                 summary: Example payload for updating a user
                 value:
                   name: John Doe
                   email: john.doe@example.com
-                  age:  30
+                  age: 30
                   is_active: true
+                  total_points_earned: 1000
+                  membership_level: 3
         required: true
       responses:
-        '200':
+        "200":
           description: User updated successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserOut'
+                $ref: "#/components/schemas/UserOut"
               examples:
                 example1:
                   summary: Example response for an updated user
                   value:
-                    id:  1
+                    id: 1
                     name: John Doe
                     email: john.doe@example.com
-                    age:  30
+                    age: 30
                     is_active: true
     delete:
       summary: Delete a specific user by ID
@@ -133,7 +135,7 @@ paths:
           schema:
             type: integer
       responses:
-        '204':
+        "204":
           description: User deleted successfully
 components:
   schemas:
@@ -149,6 +151,14 @@ components:
           type: integer
         is_active:
           type: boolean
+        total_points_earned:
+          type: integer
+          format: int64
+          description: Total loyalty/reward points accumulated by the user
+        membership_level:
+          type: integer
+          format: int32
+          description: User's membership tier level
       required:
         - name
         - email
@@ -156,7 +166,7 @@ components:
         - is_active
     UserOut:
       allOf:
-        - $ref: '#/components/schemas/UserIn'
+        - $ref: "#/components/schemas/UserIn"
         - type: object
           properties:
             id:

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING
 
 import orjson
@@ -5,7 +6,7 @@ import pytest
 
 from openapi_tester import SchemaTester
 from openapi_tester.clients import OpenAPINinjaClient
-from openapi_tester.exceptions import UndocumentedSchemaSectionError
+from openapi_tester.exceptions import DocumentationError, UndocumentedSchemaSectionError
 from test_project.api.ninja.api import router
 
 if TYPE_CHECKING:
@@ -29,6 +30,13 @@ def test_get_users(client: OpenAPINinjaClient):
 def test_get_user(client: OpenAPINinjaClient):
     response = client.get("/1")
     assert response.status_code == 200
+
+
+def test_get_user_with_larger_than_int64_integer(client: OpenAPINinjaClient):
+    with pytest.raises(DocumentationError) as error:
+        client.get("/2")
+
+    assert 'Expected: a "int64" formatted "integer" value' in str(error.value)
 
 
 def test_create_user(client: OpenAPINinjaClient):
@@ -59,6 +67,45 @@ def test_update_user(client: OpenAPINinjaClient):
         content_type="application/json",
     )
     assert response.status_code == 200
+
+
+def test_update_user_with_int_fields(client: OpenAPINinjaClient):
+    payload = {
+        "name": "John Doe",
+        "email": "john.doe@example.com",
+        "age": 35,
+        "is_active": True,
+        "total_points_earned": 1000,
+        "membership_level": 3,
+    }
+
+    response = client.put(
+        path="/1",
+        data=orjson.dumps(payload).decode("utf-8"),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+
+
+def test_update_user_with_int_fields_out_of_range(client: OpenAPINinjaClient):
+    payload = {
+        "name": "John Doe",
+        "email": "john.doe@example.com",
+        "age": 35,
+        "is_active": True,
+        "total_points_earned": 2**64,
+        "membership_level": 6,
+    }
+
+    with pytest.raises(DocumentationError):
+        client.put(
+            path="/1",
+            data=json.dumps(
+                payload
+            ),  # using json.dumps as orjson doesn't support integer value types > int64 - https://github.com/ijl/orjson/issues/301
+            content_type="application/json",
+        )
 
 
 def test_delete_user(client: OpenAPINinjaClient):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -61,6 +61,8 @@ TEST_DATA_MAP: dict[str, tuple[Any, Any]] = {
     "double": (faker.pyfloat(), faker.pyint()),
     "email": (faker.email(), faker.pystr()),
     "float": (faker.pyfloat(), faker.pyint()),
+    "int32": (faker.pyint(min_value=-(2**31), max_value=2**31 - 1), faker.pystr()),
+    "int64": (faker.pyint(min_value=-(2**63), max_value=2**63 - 1), faker.pystr()),
     "ipv4": (faker.ipv4(), faker.pystr()),
     "ipv6": (faker.ipv6(), faker.pystr()),
     "time": (faker.time(), faker.pystr()),
@@ -439,3 +441,17 @@ def test_validate_unique_items_dict():
         == "The array [{'id': 123, 'type': 'Potato'}, {'id': 234, 'type': 'Potato'}, "
         "{'type': 'Potato', 'id': 123}] must contain unique items only"
     )
+
+
+def test_int32_validation():
+    tester.test_schema_section({"type": "integer", "format": "int32"}, 123)
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section({"type": "integer", "format": "int32"}, 2**32)
+
+
+def test_int64_validation():
+    tester.test_schema_section({"type": "integer", "format": "int64"}, 123)
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section({"type": "integer", "format": "int64"}, 2**64)


### PR DESCRIPTION
Within the current included `format` validations for each of the types defined, the two supported formats for `integer` values (`int32` and `int64`) are missing. 
Adding corresponding validations for these formats.
