### PR TITLE
feat: adding proper 'null' type validation for openapi 3.1.x

### DIFF
--- a/openapi_tester/validators.py
+++ b/openapi_tester/validators.py
@@ -83,6 +83,7 @@ VALIDATOR_MAP: dict[str, Callable] = {
     ),
     "object": create_validator(lambda x: isinstance(x, dict), True),
     "array": create_validator(lambda x: isinstance(x, list), True),
+    "null": create_validator(lambda x: x is None, True),
     # by format
     "byte": base64_format_validator,
     "base64": base64_format_validator,

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -388,14 +388,9 @@ def test_validate_request_schema_with_prefix_in_server_path_prefix(
     schema_tester.validate_request(ResponseHandlerFactory.create(response=response))
 
 
-def test_is_openapi_schema(pets_api_schema: Path):
+def test_get_openapi_schema(pets_api_schema: Path):
     schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
-    assert schema_tester.is_openapi_schema() is True
-
-
-def test_is_openapi_schema_false():
-    schema_tester = SchemaTester()
-    assert schema_tester.is_openapi_schema() is False
+    assert schema_tester.get_openapi_schema() == "3.1.0"
 
 
 def test_get_request_body_schema_section(

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from faker import Faker
@@ -47,6 +48,7 @@ TEST_DATA_MAP: dict[str, tuple[Any, Any]] = {
     "number": (faker.pyfloat(), faker.pybool()),
     "object": (faker.pydict(), faker.pystr()),
     "array": (faker.pylist(), faker.pystr()),
+    "null": (None, faker.pystr()),
     # by format
     "byte": (
         base64.b64encode(faker.pystr().encode("utf-8")).decode("utf-8"),
@@ -412,6 +414,40 @@ def test_is_nullable_oneof():
     with pytest.raises(DocumentationError):
         tester.test_schema_section(
             {"oneOf": [{"type": "object"}, {"type": "string"}]}, None
+        )
+
+
+@patch(
+    "openapi_tester.schema_tester.SchemaTester.get_openapi_schema", return_value="3.1.0"
+)
+def test_null_validation(mock_get_openapi_schema):
+    tester.test_schema_section({"type": ["null", "integer"]}, None)
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section({"type": "integer"}, "test")
+
+
+@patch(
+    "openapi_tester.schema_tester.SchemaTester.get_openapi_schema", return_value="3.1.0"
+)
+def test_is_nullable_null_openapi_3_1_validation_one_of(mock_get_openapi_schema):
+    tester.test_schema_section({"oneOf": [{"type": "integer"}, {"type": "null"}]}, None)
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(
+            {"oneOf": [{"type": "integer"}, {"type": "null"}]}, "test"
+        )
+
+
+@patch(
+    "openapi_tester.schema_tester.SchemaTester.get_openapi_schema", return_value="3.1.0"
+)
+def test_is_nullable_null_openapi_3_1_validation_any_of(mock_get_openapi_schema):
+    tester.test_schema_section({"anyOf": [{"type": "integer"}, {"type": "null"}]}, None)
+
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(
+            {"anyOf": [{"type": "integer"}, {"type": "null"}]}, "test"
         )
 
 


### PR DESCRIPTION
The proper validation for `null` type is not working when using `anyOf` and `oneOf`. 
Given that `null` is a defined [data type](https://spec.openapis.org/oas/v3.1.1.html#data-types) in OpenAPI 3.1.x, adding the proper validation for this type, and avoiding calling `test_is_nullable` when the schema under test is not OpenAPI 3.1.x.
