### PR TITLE
Multiple types with multiple restrictions + `null` type remaining scenarios

### DIFF
--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -511,6 +511,9 @@ class SchemaTester:
                     f"\n\n {test_config.http_message.capitalize()} value:\n  {data}"
                     f"\n Schema description:\n  {schema_section}"
                 )
+            # Add early return for null data after type validation succeeds
+            if data is None and validator.__name__ == "validate_type":
+                return
 
         if schema_section_type == "object":
             self.test_openapi_object(

--- a/openapi_tester/validators.py
+++ b/openapi_tester/validators.py
@@ -164,6 +164,8 @@ def validate_enum(schema_section: dict[str, Any], data: Any) -> str | None:
 
 
 def validate_pattern(schema_section: dict[str, Any], data: str) -> str | None:
+    if not isinstance(data, str):
+        return None
     pattern = schema_section.get("pattern")
     if not pattern:
         return None
@@ -179,6 +181,8 @@ def validate_pattern(schema_section: dict[str, Any], data: str) -> str | None:
 def validate_multiple_of(
     schema_section: dict[str, Any], data: int | float
 ) -> str | None:
+    if not isinstance(data, (int, float)):
+        return None
     multiple = schema_section.get("multipleOf")
     if multiple and data % multiple != 0:
         return VALIDATE_MULTIPLE_OF_ERROR.format(data=data, multiple=multiple)
@@ -186,22 +190,40 @@ def validate_multiple_of(
 
 
 def validate_maximum(schema_section: dict[str, Any], data: int | float) -> str | None:
+    if not isinstance(data, (int, float)):
+        return None
+
     maximum = schema_section.get("maximum")
+
+    if not isinstance(maximum, (int, float)):
+        return None
+
     exclusive_maximum = schema_section.get("exclusiveMaximum")
-    if maximum and exclusive_maximum and data >= maximum:
+
+    if exclusive_maximum and data >= maximum:
         return VALIDATE_MAXIMUM_ERROR.format(data=data, maximum=maximum - 1)
-    if maximum and not exclusive_maximum and data > maximum:
+    if not exclusive_maximum and data > maximum:
         return VALIDATE_MAXIMUM_ERROR.format(data=data, maximum=maximum)
+
     return None
 
 
 def validate_minimum(schema_section: dict[str, Any], data: int | float) -> str | None:
+    if not isinstance(data, (int, float)):
+        return None
+
     minimum = schema_section.get("minimum")
+
+    if not isinstance(minimum, (int, float)):
+        return None
+
     exclusive_minimum = schema_section.get("exclusiveMinimum")
-    if minimum and exclusive_minimum and data <= minimum:
+
+    if exclusive_minimum and data <= minimum:
         return VALIDATE_MINIMUM_ERROR.format(data=data, minimum=minimum + 1)
-    if minimum and not exclusive_minimum and data < minimum:
+    if not exclusive_minimum and data < minimum:
         return VALIDATE_MINIMUM_ERROR.format(data=data, minimum=minimum)
+
     return None
 
 
@@ -222,6 +244,8 @@ def validate_unique_items(
 
 
 def validate_min_length(schema_section: dict[str, Any], data: str) -> str | None:
+    if not isinstance(data, str):
+        return None
     min_length: int | None = schema_section.get("minLength")
     if min_length and len(data) < min_length:
         return VALIDATE_MIN_LENGTH_ERROR.format(data=data, min_length=min_length)
@@ -229,6 +253,8 @@ def validate_min_length(schema_section: dict[str, Any], data: str) -> str | None
 
 
 def validate_max_length(schema_section: dict[str, Any], data: str) -> str | None:
+    if not isinstance(data, str):
+        return None
     max_length: int | None = schema_section.get("maxLength")
     if max_length and len(data) > max_length:
         return VALIDATE_MAX_LENGTH_ERROR.format(data=data, max_length=max_length)
@@ -236,6 +262,8 @@ def validate_max_length(schema_section: dict[str, Any], data: str) -> str | None
 
 
 def validate_min_items(schema_section: dict[str, Any], data: list) -> str | None:
+    if not isinstance(data, list):
+        return None
     min_length: int | None = schema_section.get("minItems")
     if min_length and len(data) < min_length:
         return VALIDATE_MIN_ARRAY_LENGTH_ERROR.format(data=data, min_length=min_length)
@@ -243,6 +271,8 @@ def validate_min_items(schema_section: dict[str, Any], data: list) -> str | None
 
 
 def validate_max_items(schema_section: dict[str, Any], data: list) -> str | None:
+    if not isinstance(data, list):
+        return None
     max_length: int | None = schema_section.get("maxItems")
     if max_length and len(data) > max_length:
         return VALIDATE_MAX_ARRAY_LENGTH_ERROR.format(data=data, max_length=max_length)
@@ -250,6 +280,8 @@ def validate_max_items(schema_section: dict[str, Any], data: list) -> str | None
 
 
 def validate_min_properties(schema_section: dict[str, Any], data: dict) -> str | None:
+    if not isinstance(data, dict):
+        return None
     min_properties: int | None = schema_section.get("minProperties")
     if min_properties and len(data.keys()) < int(min_properties):
         return VALIDATE_MINIMUM_NUMBER_OF_PROPERTIES_ERROR.format(
@@ -259,6 +291,8 @@ def validate_min_properties(schema_section: dict[str, Any], data: dict) -> str |
 
 
 def validate_max_properties(schema_section: dict[str, Any], data: dict) -> str | None:
+    if not isinstance(data, dict):
+        return None
     max_properties: int | None = schema_section.get("maxProperties")
     if max_properties and len(data.keys()) > int(max_properties):
         return VALIDATE_MAXIMUM_NUMBER_OF_PROPERTIES_ERROR.format(

--- a/tests/test_validator_errors.py
+++ b/tests/test_validator_errors.py
@@ -22,6 +22,8 @@ from openapi_tester.validators import (
     validate_unique_items,
 )
 
+tester = SchemaTester()
+
 
 def test_case_error_message():
     error = CaseError(key="test-key", case="camelCase", expected="testKey")
@@ -230,3 +232,50 @@ def test_one_of_error():
         tester.test_schema_section(
             {"oneOf": []}, {}, OpenAPITestConfig(reference="init")
         )
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "abcd",
+        7,
+        "1234",
+        "abc",
+    ],
+)
+def test_string_integer_pattern_multiple_of_invalid(input_value):
+    """Test invalid cases for string and integer type with pattern and multiple of restrictions."""
+    schema = {"type": ["string", "integer"], "pattern": "^[A-Z]{1,3}$", "multipleOf": 5}
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(schema, input_value)
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "abcd",
+        -1,
+        11,
+        True,
+    ],
+)
+def test_string_number_multiple_restrictions_invalid(input_value):
+    """Test invalid cases for string and number type with multiple restrictions."""
+    schema = {"type": ["string", "number"], "maxLength": 3, "minimum": 0, "maximum": 10}
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(schema, input_value)
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "test1",
+        1,
+        0,
+    ],
+)
+def test_string_integer_length_minimum_restrictions_invalid(input_value):
+    """Test invalid cases for string and integer type with length and minimum restrictions."""
+    schema = {"type": ["string", "integer"], "maxLength": 4, "minimum": 2}
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(schema, input_value)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -461,7 +461,7 @@ def test_is_nullable_null_openapi_3_1_validation_date_time_format(
     tester.test_schema_section(schema, None)
     tester.test_schema_section(schema, "2025-04-29T00:00:00+01:00")
     with pytest.raises(DocumentationError):
-        tester.test_schema_section(schema, "asd")
+        tester.test_schema_section(schema, "test")
 
 
 @patch(
@@ -484,6 +484,46 @@ def test_is_nullable_null_openapi_3_1_validation_min_length(mock_get_openapi_sch
     tester.test_schema_section(schema, "a string")
     with pytest.raises(DocumentationError):
         tester.test_schema_section(schema, "")
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        "test",
+        "t",
+        2,
+        5,
+    ],
+)
+def test_string_integer_length_minimum_restrictions_valid(input_value):
+    """Test string and integer type with length and minimum restrictions."""
+    schema = {"type": ["string", "integer"], "maxLength": 4, "minimum": 2}
+    try:
+        tester.test_schema_section(schema, input_value)
+    except DocumentationError as e:
+        pytest.fail(
+            f"Validation failed for valid input: {input_value}. Error: {str(e)}"
+        )
+
+
+def test_string_number_multiple_restrictions_valid():
+    """Test string and number type with multiple restrictions."""
+    schema = {"type": ["string", "number"], "maxLength": 3, "minimum": 0, "maximum": 10}
+
+    tester.test_schema_section(schema, "abc")
+    tester.test_schema_section(schema, 0)
+    tester.test_schema_section(schema, 10)
+    tester.test_schema_section(schema, 5.5)
+
+
+def test_string_integer_pattern_multiple_of_valid():
+    """Test string and integer type with pattern and multiple of restrictions."""
+    schema = {"type": ["string", "integer"], "pattern": "^[A-Z]{1,3}$", "multipleOf": 5}
+
+    tester.test_schema_section(schema, "ABC")
+    tester.test_schema_section(schema, "A")
+    tester.test_schema_section(schema, 5)
+    tester.test_schema_section(schema, 15)
 
 
 def test_validate_unique_items_dict():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -451,6 +451,41 @@ def test_is_nullable_null_openapi_3_1_validation_any_of(mock_get_openapi_schema)
         )
 
 
+@patch(
+    "openapi_tester.schema_tester.SchemaTester.get_openapi_schema", return_value="3.1.0"
+)
+def test_is_nullable_null_openapi_3_1_validation_date_time_format(
+    mock_get_openapi_schema,
+):
+    schema = {"type": ["string", "null"], "format": "date-time"}
+    tester.test_schema_section(schema, None)
+    tester.test_schema_section(schema, "2025-04-29T00:00:00+01:00")
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(schema, "asd")
+
+
+@patch(
+    "openapi_tester.schema_tester.SchemaTester.get_openapi_schema", return_value="3.1.0"
+)
+def test_is_nullable_null_openapi_3_1_validation_email_format(mock_get_openapi_schema):
+    schema = {"type": ["string", "null"], "format": "email"}
+    tester.test_schema_section(schema, None)
+    tester.test_schema_section(schema, "test@gmail.com")
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(schema, "notanemail")
+
+
+@patch(
+    "openapi_tester.schema_tester.SchemaTester.get_openapi_schema", return_value="3.1.0"
+)
+def test_is_nullable_null_openapi_3_1_validation_min_length(mock_get_openapi_schema):
+    schema = {"type": ["string", "null"], "minLength": 1}
+    tester.test_schema_section(schema, None)
+    tester.test_schema_section(schema, "a string")
+    with pytest.raises(DocumentationError):
+        tester.test_schema_section(schema, "")
+
+
 def test_validate_unique_items_dict():
     # Only unique objects.
     result = validate_unique_items(


### PR DESCRIPTION
- Adding proper validation for schemas with multiple types defined and multiple restrictions.
- Adding remaining validation scenarios for `null` type in OpenAPI 3.1.x