### PR TITLE
feat: adding request query parameters validation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -90,5 +90,5 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,60 @@ class MyAPITests(BaseAPITestCase):
         self.assertResponse(response)
 ```
 
+## Response and Request Validation
+
+The `SchemaTester` instance (as initialized in the "Usage" section) provides two main methods for validating your API interactions against the OpenAPI schema: `validate_response` and `validate_request`. These methods are typically used within your test functions after an API call has been made.
+
+### Response Validation
+
+`schema_tester.validate_response(response)`: This method inspects the HTTP response received from your application. It checks if the structure and data types of the response body conform to the OpenAPI schema definition for that specific endpoint, HTTP method, and status code.
+
+For example:
+```python
+# Assuming schema_tester is an initialized instance of SchemaTester
+
+def test_get_item_response(client):
+    response = client.get('/api/v1/items/1')
+    assert response.status_code == 200
+    # Validates the content of 'response' against the schema's 200 OK definition for GET /api/v1/items/1
+    schema_tester.validate_response(response=response)
+```
+
+### Request Validation
+
+`schema_tester.validate_request(response)`: This method validates the original request that led to the given `response`. The validation scope includes:
+*   **Request Body**: For HTTP methods like `POST`, `PUT`, `PATCH`, it checks if the submitted payload matches the schema.
+*   **Query Parameters**: For all relevant HTTP methods (including `GET`), it verifies if the query parameters used in the request are consistent with those defined in the OpenAPI specification.
+
+**Validation on Success**
+
+Request validation is performed *only if* the associated `response` indicates a successful operation (e.g., status codes in the `2xx` range).
+
+**Rationale**: The OpenAPI schema primarily defines the contract for *valid and successful* API interactions. If a request is malformed to the extent that the server rejects it (e.g., with a `400 Bad Request` or `422 Unprocessable Entity`), the server's error response itself is the primary indicator of the problem. `validate_request` focuses on ensuring that requests which *are* successfully processed by the application indeed adhere to the documented contract. It's not intended to diagnose why an already failed request was invalid, as the schema might not even cover such error-inducing request structures.
+This ensures as well that the package validation won't interfere with your functional negative test cases suite.
+
+Examples:
+```python
+# Assuming schema_tester is an initialized instance of SchemaTester
+
+def test_create_item_request(client):
+    payload = {'name': 'A new gizmo', 'price': 25.99}
+    response = client.post('/api/v1/items', data=payload, content_type='application/json')
+    assert response.status_code == 201  # Or 200, 202, 204 etc.
+    # Because the response is successful (201), this will validate:
+    # 1. The 'payload' sent in the POST request.
+    # 2. Any query parameters, if the POST endpoint defined them (uncommon for POST).
+    schema_tester.validate_request(response=response)
+
+def test_list_items_with_filters_request(client):
+    response = client.get('/api/v1/items?status=active&limit=10')
+    assert response.status_code == 200
+    # Because the response is successful (200), this will validate:
+    # 1. That 'status' and 'limit' are valid query parameters for this endpoint.
+    # 2. That their values ('active', 10) are of the correct type/format.
+    schema_tester.validate_request(response=response)
+```
+
 ## Options
 
 You can pass options either globally, when instantiating a `SchemaTester`, or locally, when

--- a/openapi_tester/constants.py
+++ b/openapi_tester/constants.py
@@ -45,8 +45,17 @@ VALIDATE_MISSING_KEY_ERROR = (
     "The following property was found in the schema definition, "
     'but is missing from the {http_message} data: "{missing_key}"'
 )
+VALIDATE_MISSING_QUERY_PARAM_ERROR = (
+    "The following query parameter was found in the schema definition, "
+    'but is missing from the {http_message} data: "{missing_key}"'
+)
+
 VALIDATE_EXCESS_KEY_ERROR = (
     "The following property was found in the {http_message} data, "
+    'but is missing from the schema definition: "{excess_key}"'
+)
+VALIDATE_EXCESS_QUERY_PARAM_ERROR = (
+    "The following query parameter was found in the {http_message}, "
     'but is missing from the schema definition: "{excess_key}"'
 )
 VALIDATE_WRITE_ONLY_RESPONSE_KEY_ERROR = 'The following property was found in the response, but is documented as being "writeOnly": "{write_only_key}"'

--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -729,9 +729,8 @@ class SchemaTester:
         test_config: OpenAPITestConfig | None = None,
     ) -> None:
         """
-        Verifies that an OpenAPI schema definition matches an API request:
-
-        * Validates
+        Verifies that an OpenAPI schema definition matches an API request,
+        validating both query parameters and request body.
 
         :param response_handler: The HTTP response handler (can be a DRF or Ninja response)
         :param test_config: Optional object with test configuration

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -102,3 +102,24 @@ def get_required_keys(
             if key not in write_only_props
         ]
     return []
+
+
+def query_params_to_object(query_params: list[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Convert the query parameters of a request to an object schema,
+    in order to be able to be validated.
+    """
+    properties = {}
+    required = []
+
+    for param in query_params:
+        param_name = param["name"]
+        properties[param_name] = param.get("schema", {})
+        if param.get("required", False):
+            required.append(param_name)
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    }

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -118,8 +118,15 @@ def query_params_to_object(query_params: list[dict[str, Any]]) -> dict[str, Any]
         if param.get("required", False):
             required.append(param_name)
 
-    return {
-        "type": "object",
-        "properties": properties,
-        "required": required,
-    }
+    if properties:
+        query_params_object = {
+            "type": "object",
+            "properties": properties,
+        }
+
+        if len(required) > 0:
+            query_params_object["required"] = required
+
+        return query_params_object
+
+    return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-contract-tester"
-version = "1.5.3"
+version = "1.6.0"
 description = "Test utility for validating OpenAPI response documentation"
 authors =["Matías Cárdenas <cardenasmatias.1990@gmail.com>", "Sondre Lillebø Gundersen <sondrelg@live.no>", "Na'aman Hirschfeld <nhirschfeld@gmail.com>"]
 license = "BSD-4-Clause"

--- a/test_project/api/ninja/api.py
+++ b/test_project/api/ninja/api.py
@@ -1,8 +1,13 @@
-from typing import List
+from typing import List, Optional
 
-from ninja import NinjaAPI, Router
+from ninja import NinjaAPI, Query, Router
 
-from test_project.api.ninja.schemas import UserIn, UserOut
+from test_project.api.ninja.schemas import (
+    UserIn,
+    UserOut,
+    UserProfileFilter,
+    UserProfileOut,
+)
 
 ninja_api = NinjaAPI()
 
@@ -20,8 +25,24 @@ def create_user(request, user: UserIn):
     }
 
 
+@router.get("/profiles", response={200: List[UserProfileOut]})
+def get_user_profile(request, query: Query[UserProfileFilter]):
+    return [
+        {
+            "id": 1,
+            "name": "John Doe",
+            "email": "john.doe@example.com",
+            "membership_level": 3,
+            "points": 1000,
+            "join_date": "2021-01-01",
+            "is_active": True,
+            "last_login": "2021-01-01",
+        }
+    ]
+
+
 @router.get("/{user_id}", response={200: UserOut})
-def get_user(request, user_id: int):
+def get_user(request, user_id: int, name: Optional[str] = ""):
     if user_id == 1:
         return {
             "id": 1,

--- a/test_project/api/ninja/schemas.py
+++ b/test_project/api/ninja/schemas.py
@@ -1,4 +1,6 @@
-from ninja import Schema
+from typing import Optional
+
+from ninja import FilterSchema, Schema
 
 
 class UserIn(Schema):
@@ -32,4 +34,43 @@ class UserOut(UserIn):
             "is_active": True,
             "membership_level": 3,
             "total_points_earned": 1000,
+        }
+
+
+class UserProfileOut(Schema):
+    id: int
+    name: str
+    email: str
+    membership_level: int
+    points: int
+    join_date: str
+    last_login: str
+    is_active: bool
+
+    class Config:
+        example = {
+            "id": 1,
+            "name": "John Doe",
+            "email": "john.doe@example.com",
+            "membership_level": 3,
+            "points": 1000,
+            "join_date": "2021-01-01",
+            "last_login": "2021-01-01",
+            "is_active": True,
+        }
+
+
+class UserProfileFilter(FilterSchema):
+    membership_level: int
+    min_points: Optional[int] = None
+    is_active: str = "yes"
+    join_date: Optional[str] = None
+    search: Optional[str] = None
+    sort_by: Optional[str] = None
+    sort_order: Optional[str] = None
+
+    class Config:
+        example = {
+            "membership_level": 3,
+            "min_points": 1000,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,17 @@ def pets_post_request():
 
 
 @pytest.fixture
+def pets_get_request():
+    return GenericRequest(
+        method="get",
+        path="/api/pets",
+        data={},
+        headers={"Content-Type": "application/json"},
+        query_params={"tags": ["dog", "cat"]},
+    )
+
+
+@pytest.fixture
 def invalid_pets_post_request():
     request_body = MagicMock()
     request_body.read.return_value = b'{"surname": "doggie", "species": "dog"}'
@@ -78,6 +89,7 @@ def response_factory() -> Callable:
                     method=request.method,
                     data=request.data,
                     headers=request.headers,
+                    query_params=request.query_params,
                 )
             }
         else:
@@ -87,6 +99,7 @@ def response_factory() -> Callable:
                     method=method,
                     data={},
                     headers={},
+                    query_params={},
                 )
             }
 

--- a/tests/schemas/users_django_api_schema.yaml
+++ b/tests/schemas/users_django_api_schema.yaml
@@ -38,6 +38,12 @@ paths:
                     is_active: true
     get:
       summary: Get all users
+      parameters:
+        - name: age
+          in: query
+          required: false
+          schema:
+            type: integer
       responses:
         "200":
           description: All users retrieved successfully
@@ -70,6 +76,11 @@ paths:
           required: true
           schema:
             type: integer
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: User retrieved successfully
@@ -137,6 +148,91 @@ paths:
       responses:
         "204":
           description: User deleted successfully
+  /ninja_api/users/profiles:
+    get:
+      summary: Get user profiles with filtering options
+      parameters:
+        - name: membership_level
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 5
+            description: User's membership tier level (1-5)
+        - name: min_points
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            description: Minimum points threshold
+        - name: is_active
+          in: query
+          required: false
+          schema:
+            type: boolean
+            description: Filter by active status
+        - name: join_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+            description: Filter by join date (YYYY-MM-DD)
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 2
+            maxLength: 10
+            description: Search term for name or email
+        - name: sort_by
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [points, join_date, membership_level]
+            default: points
+            description: Field to sort results by
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+            description: Sort order direction
+      responses:
+        "200":
+          description: User profiles retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/UserProfile"
+              examples:
+                example1:
+                  summary: Example response for user profiles
+                  value:
+                    - id: 1
+                      name: John Doe
+                      email: john.doe@example.com
+                      membership_level: 3
+                      points: 1500
+                      join_date: "2023-01-15"
+                      is_active: true
+                      last_login: "2024-03-20T14:30:00Z"
+                    - id: 2
+                      name: Jane Doe
+                      email: jane.doe@example.com
+                      membership_level: 4
+                      points: 2500
+                      join_date: "2023-03-20"
+                      is_active: true
+                      last_login: "2024-03-19T09:15:00Z"
 components:
   schemas:
     UserIn:
@@ -173,3 +269,36 @@ components:
               type: integer
           required:
             - id
+    UserProfile:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        membership_level:
+          type: integer
+          minimum: 1
+          maximum: 5
+        points:
+          type: integer
+          minimum: 0
+        join_date:
+          type: string
+          format: date
+        is_active:
+          type: boolean
+        last_login:
+          type: string
+          format: date
+      required:
+        - id
+        - name
+        - email
+        - membership_level
+        - points
+        - join_date
+        - is_active

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -1,5 +1,6 @@
 import json
 from typing import TYPE_CHECKING
+from urllib.parse import urlencode
 
 import orjson
 import pytest
@@ -30,6 +31,54 @@ def test_get_users(client: OpenAPINinjaClient):
 def test_get_user(client: OpenAPINinjaClient):
     response = client.get("/1")
     assert response.status_code == 200
+
+
+def test_get_user_by_name(client: OpenAPINinjaClient):
+    query_params = {"name": "John Doe"}
+    response = client.get(f"/1?{urlencode(query_params)}")
+    assert response.status_code == 200
+
+
+def test_get_user_with_undocumented_query_param(client: OpenAPINinjaClient):
+    query_params = {"name": "John Doe", "date_of_birth": "12/12/1990"}
+
+    with pytest.raises(DocumentationError) as error:
+        client.get(f"/1?{urlencode(query_params)}")
+
+    assert (
+        'The following query parameter was found in the request, but is missing from the schema definition: "date_of_birth"'
+        in str(error.value)
+    )
+
+
+def test_get_user_profile(client: OpenAPINinjaClient):
+    query_params = {"membership_level": 3}
+    response = client.get(f"/profiles?{urlencode(query_params)}")
+    assert response.status_code == 200
+
+
+def test_get_user_profile_undocumented_query_param(client: OpenAPINinjaClient):
+    query_params = {"membership_level": 3, "date_of_birth": "12/12/1990"}
+    with pytest.raises(DocumentationError) as error:
+        client.get(f"/profiles?{urlencode(query_params)}")
+
+    assert (
+        'The following query parameter was found in the request, but is missing from the schema definition: "date_of_birth"'
+        in str(error.value)
+    )
+
+
+def test_get_user_profile_with_documented_query_param_incompatible_format(
+    client: OpenAPINinjaClient,
+):
+    query_params = {
+        "membership_level": 3,
+        "is_active": "yes",
+    }  # defined as boolean in schema
+    with pytest.raises(DocumentationError) as error:
+        client.get(f"/profiles?{urlencode(query_params)}")
+
+    assert 'Expected: a "boolean" type value' in str(error.value)
 
 
 def test_get_user_with_larger_than_int64_integer(client: OpenAPINinjaClient):

--- a/tests/test_openapi_query_params_object.py
+++ b/tests/test_openapi_query_params_object.py
@@ -1,0 +1,181 @@
+import pytest
+
+from openapi_tester import SchemaTester
+from openapi_tester.config import OpenAPITestConfig
+from openapi_tester.exceptions import DocumentationError
+
+
+def test_openapi_query_params_object():
+    schema_section = {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "limit": {"type": "integer", "format": "int32"},
+        },
+    }
+
+    query_params = {
+        "tags": ["dog", "cat"],
+        "limit": 10,
+    }
+
+    tester = SchemaTester()
+
+    tester.test_openapi_query_params_object(
+        schema_section=schema_section,
+        data=query_params,
+        test_config=OpenAPITestConfig(
+            reference="GET /endpoint > query_params", http_message="request"
+        ),
+    )
+
+
+def test_openapi_query_params_object_no_query_params():
+    schema_section = {
+        "type": "object",
+        "properties": {},
+    }
+
+    query_params = {}
+
+    tester = SchemaTester()
+
+    tester.test_openapi_query_params_object(
+        schema_section=schema_section,
+        data=query_params,
+        test_config=OpenAPITestConfig(
+            reference="GET /endpoint > query_params", http_message="request"
+        ),
+    )
+
+
+def test_openapi_query_params_object_missing_required_query_param():
+    expected_error_message = (
+        'The following query parameter was found in the schema definition, but is missing from the request data: "tags"'
+        "\n\nReference:\n\nGET /endpoint > query_params > tags\n\nRequest Query param:\n  {}\nSchema section:"
+        '\n  {\n  "tags": {\n    "type": "array",\n    "items": {\n      "type": "string"\n    }\n  }\n}\n\n'
+        "Hint: Remove the key from your OpenAPI docs, or include it in your API request"
+    )
+    schema_section = {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["tags"],
+    }
+
+    query_params = {}
+
+    tester = SchemaTester()
+
+    with pytest.raises(DocumentationError, match=expected_error_message):
+        tester.test_openapi_query_params_object(
+            schema_section=schema_section,
+            data=query_params,
+            test_config=OpenAPITestConfig(
+                reference="GET /endpoint > query_params", http_message="request"
+            ),
+        )
+
+
+def test_excess_query_param_in_request():
+    expected_error_message = (
+        'The following query parameter was found in the request, but is missing from the schema definition: "new_tag"'
+        '\n\nReference:\n\nGET /endpoint > query_params > new_tag\n\nRequest query parameters:\n  {\n  "new_tag": "new_tag_value"\n}'
+        '\n\nQuery parameters\' Schema section:\n  {\n  "tags": {\n    "type": "array",\n    "items": {\n      "type": "string"\n    }\n  },'
+        '\n  "limit": {\n    "type": "integer",\n    "format": "int32"\n  }\n}\n\nHint: Remove the query parameter from your API request, or include it in your OpenAPI docs'
+    )
+
+    tester = SchemaTester()
+
+    schema_section = {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "limit": {"type": "integer", "format": "int32"},
+        },
+        "required": [],
+    }
+
+    query_params = {
+        "new_tag": "new_tag_value",
+    }
+
+    with pytest.raises(DocumentationError, match=expected_error_message):
+        tester.test_openapi_query_params_object(
+            schema_section=schema_section,
+            data=query_params,
+            test_config=OpenAPITestConfig(
+                reference="GET /endpoint > query_params", http_message="request"
+            ),
+        )
+
+
+def test_openapi_query_params_object_invalid_query_param_type():
+    expected_error_message = (
+        '\n\nExpected: an "integer" type value\n\nReceived: "not_an_integer"\n\nReference: \n\n'
+        "GET /endpoint > query_params > limit\n\n Request value:\n  not_an_integer\n "
+        "Schema description:\n  {'type': 'integer', 'format': 'int32'}"
+    )
+
+    tester = SchemaTester()
+
+    schema_section = {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "format": "int32"},
+        },
+    }
+
+    query_params = {"limit": "not_an_integer"}
+
+    with pytest.raises(DocumentationError, match=expected_error_message):
+        tester.test_openapi_query_params_object(
+            schema_section=schema_section,
+            data=query_params,
+            test_config=OpenAPITestConfig(
+                reference="GET /endpoint > query_params", http_message="request"
+            ),
+        )
+
+
+def test_openapi_query_params_object_email_format():
+    expected_error_message = (
+        '\n\nExpected: a "email" formatted "string" value\n\nReceived: "not_an_email"\n\nReference: \n\n'
+        "GET /endpoint > query_params > email\n\n Request value:\n  not_an_email\n "
+        "Schema description:\n  {'type': 'string', 'format': 'email'}"
+    )
+
+    tester = SchemaTester()
+
+    schema_section = {
+        "type": "object",
+        "properties": {
+            "email": {"type": "string", "format": "email"},
+        },
+    }
+
+    query_params = {
+        "email": "valid_test_email@example.com",
+    }
+
+    tester.test_openapi_query_params_object(
+        schema_section=schema_section,
+        data=query_params,
+        test_config=OpenAPITestConfig(
+            reference="GET /endpoint > query_params", http_message="request"
+        ),
+    )
+
+    query_params = {
+        "email": "not_an_email",
+    }
+
+    with pytest.raises(DocumentationError, match=expected_error_message):
+        tester.test_openapi_query_params_object(
+            schema_section=schema_section,
+            data=query_params,
+            test_config=OpenAPITestConfig(
+                reference="GET /endpoint > query_params", http_message="request"
+            ),
+        )

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -450,7 +450,6 @@ def test_get_query_params_schema_section(
             "tags": {"type": "array", "items": {"type": "string"}},
             "limit": {"type": "integer", "format": "int32"},
         },
-        "required": [],
     }
 
 

--- a/tests/test_schema_tester.py
+++ b/tests/test_schema_tester.py
@@ -435,6 +435,36 @@ def test_get_request_body_schema_section_no_content_request(
     assert schema_section == {}
 
 
+def test_get_query_params_schema_section(
+    pets_get_request: GenericRequest, pets_api_schema: Path
+):
+    test_config = OpenAPITestConfig(case_tester=is_pascal_case)
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    schema_section = schema_tester.get_request_query_params_schema_section(
+        request=pets_get_request, test_config=test_config
+    )
+
+    assert schema_section == {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "limit": {"type": "integer", "format": "int32"},
+        },
+        "required": [],
+    }
+
+
+def test_get_request_query_params_schema_section_no_query_params(
+    pets_post_request: GenericRequest, pets_api_schema: Path
+):
+    test_config = OpenAPITestConfig(case_tester=is_pascal_case)
+    schema_tester = SchemaTester(schema_file_path=str(pets_api_schema))
+    schema_section = schema_tester.get_request_query_params_schema_section(
+        request=pets_post_request, test_config=test_config
+    )
+    assert schema_section == {}
+
+
 def test_validate_response_global_case_tester(client):
     response = client.get(de_parameterized_path)
     with pytest.raises(CaseError, match="is not properly PascalCased"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 from openapi_tester.utils import (
     get_required_keys,
     merge_objects,
+    query_params_to_object,
     serialize_schema_section_data,
 )
 from tests.utils import sort_object
@@ -131,3 +132,23 @@ def test_get_required_keys_response_with_write_only_field():
 
     # then
     assert required_keys == ["key1"]
+
+
+def test_query_params_to_object():
+    query_params = [
+        {"name": "name", "in": "query", "required": True, "schema": {"type": "string"}},
+        {
+            "name": "age",
+            "in": "query",
+            "required": False,
+            "schema": {"type": "integer"},
+        },
+    ]
+
+    converted_query_params = query_params_to_object(query_params)
+
+    assert converted_query_params == {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+        "required": ["name"],
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,6 +136,30 @@ def test_get_required_keys_response_with_write_only_field():
 
 def test_query_params_to_object():
     query_params = [
+        {
+            "name": "name",
+            "in": "query",
+            "required": False,
+            "schema": {"type": "string"},
+        },
+        {
+            "name": "age",
+            "in": "query",
+            "required": False,
+            "schema": {"type": "integer"},
+        },
+    ]
+
+    converted_query_params = query_params_to_object(query_params)
+
+    assert converted_query_params == {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+    }
+
+
+def test_query_params_to_object_with_required_query_params():
+    query_params = [
         {"name": "name", "in": "query", "required": True, "schema": {"type": "string"}},
         {
             "name": "age",
@@ -152,3 +176,11 @@ def test_query_params_to_object():
         "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
         "required": ["name"],
     }
+
+
+def test_query_params_to_object_no_query_params():
+    query_params = []
+
+    converted_query_params = query_params_to_object(query_params)
+
+    assert converted_query_params == {}


### PR DESCRIPTION
### Overview

This PR implements query parameter validation for API requests.

Query parameters are a fundamental component of API requests and maintaining consistency between API documentation and implementation improves the developer experience and reliability of the API.

This helps to validate all query parameters used in the test suite (and implemented in the API) are properly documented and viceversa.

Note, that request validation is [only performed for scenarios with successful responses](https://github.com/maticardenas/django-contract-tester/blob/master/openapi_tester/clients.py#L45), this is to ensure the library does not interfer ewith all functional negative scenarios test cases. Nevertheless, for all successful scenarios validation will be performed, ensuring:

- Passed query parameters are included in documentation.
- Passed query parameters are consistently documented and/or implemented in terms of type and format.
- Documented required parameters are properly implemented or viceversa.

### Summary of changes

- Introduced new method for retrieving query parameters schema section, refactoring along the way also the request body schema section retrieval in order to help with reusability.
- Introduced new methods for validating query parameters object - query parameters are mapped to a OpenAPI `object`, this facilitates implementation and guarantees we can re-use existing architecture to also validate query parameters going through the test openapi section and test openapi object logic.
- Enhanced test API projects and specs in order to extend test suite for new functionality.

