### PR TITLE
fix: avoid query params validation when type defined as string

### DIFF
--- a/openapi_tester/schema_tester.py
+++ b/openapi_tester/schema_tester.py
@@ -43,6 +43,7 @@ from openapi_tester.utils import (
     normalize_schema_section,
     query_params_to_object,
     serialize_schema_section_data,
+    should_validate_query_param,
 )
 from openapi_tester.validators import (
     validate_enum,
@@ -702,6 +703,10 @@ class SchemaTester:
                 )
         for key, value in data.items():
             if key in properties:
+                if not should_validate_query_param(
+                    param_schema_section=properties[key], request_value=value
+                ):
+                    continue
                 drill_down_test_config = copy(test_config)
                 drill_down_test_config.reference = f"{test_config.reference} > {key}"
                 self.test_schema_section(

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -130,3 +130,18 @@ def query_params_to_object(query_params: list[dict[str, Any]]) -> dict[str, Any]
         return query_params_object
 
     return {}
+
+
+def should_validate_query_param(param_schema_section: dict, request_value: Any) -> bool:
+    """
+    Checks if query paramter should be validated.
+    If the query paramter is a raw string (without any format or constraints) it should not be validated.
+    If the query parameter is a string and has a format or constraints, it should be validated if the request value (after normalization) is a string.
+    """
+
+    if param_schema_section.get("type") == "string":
+        if len(param_schema_section) == 1:
+            return False
+        return isinstance(request_value, str)
+
+    return True

--- a/tests/test_openapi_query_params_object.py
+++ b/tests/test_openapi_query_params_object.py
@@ -179,3 +179,56 @@ def test_openapi_query_params_object_email_format():
                 reference="GET /endpoint > query_params", http_message="request"
             ),
         )
+
+
+def test_openapi_query_params_object_string_type_schema_section_integer_query_param():
+    tester = SchemaTester()
+
+    schema_section = {
+        "type": "object",
+        "properties": {
+            "key": {"type": "string"},
+        },
+    }
+
+    query_params = {"key": 1234}
+
+    tester.test_openapi_query_params_object(
+        schema_section=schema_section,
+        data=query_params,
+        test_config=OpenAPITestConfig(
+            reference="GET /endpoint > query_params", http_message="request"
+        ),
+    )
+
+
+def test_openapi_params_object_string_type_schema_section_with_format_string_query_param():
+    tester = SchemaTester()
+
+    schema_section = {
+        "type": "object",
+        "properties": {
+            "key": {"type": "string", "format": "email"},
+        },
+    }
+
+    query_params = {"key": "test@test.com"}
+
+    tester.test_openapi_query_params_object(
+        schema_section=schema_section,
+        data=query_params,
+        test_config=OpenAPITestConfig(
+            reference="GET /endpoint > query_params", http_message="request"
+        ),
+    )
+
+    query_params = {"key": "1234"}
+
+    with pytest.raises(DocumentationError):
+        tester.test_openapi_query_params_object(
+            schema_section=schema_section,
+            data=query_params,
+            test_config=OpenAPITestConfig(
+                reference="GET /endpoint > query_params", http_message="request"
+            ),
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from openapi_tester.utils import (
     merge_objects,
     query_params_to_object,
     serialize_schema_section_data,
+    should_validate_query_param,
 )
 from tests.utils import sort_object
 
@@ -184,3 +185,17 @@ def test_query_params_to_object_no_query_params():
     converted_query_params = query_params_to_object(query_params)
 
     assert converted_query_params == {}
+
+
+def test_should_validate_query_param():
+    assert should_validate_query_param({"type": "string"}, "123") is False
+    assert should_validate_query_param({"type": "string"}, 123) is False
+    assert (
+        should_validate_query_param(
+            {"type": "string", "format": "email"}, "test@test.com"
+        )
+        is True
+    )
+    assert (
+        should_validate_query_param({"type": "string", "format": "email"}, 123) is False
+    )


### PR DESCRIPTION
Given that query parameters are received with `string` type within the request object for both DRF and Django Ninja, we performa normalization of the same, making them adquire the proper compatible value in order to validate them properly against the `type` defined in the OpenAPI specification.

Nevertheless, this make it challenging to validate that a query parameter is sent as proper `string` (given they are always like that in the object), causing validation issues like the ones described in the [related issue](https://github.com/maticardenas/django-contract-tester/issues/64).

This PR makes the changes to avoid performing a parameter validation when the `type` is defined as `string` (without format or contraints) in the OpenAPI specs.