### PR TITLE
fix: types normalization for query parameters validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
           - drf-yasg
           - drf-spectacular
           - types-toml
+          - types-requests
           - setuptools
 
   - repo: local

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Coverage](https://codecov.io/gh/maticardenas/django-contract-tester/graph/badge.svg)](https://app.codecov.io/gh/maticardenas/django-contract-tester)
 [![Python versions](https://img.shields.io/badge/Python-3.9%2B-blue)](https://pypi.org/project/django-contract-tester/)
 [![Django versions](https://img.shields.io/badge/Django-4.2%2B-blue)](https://pypi.org/project/django-contract-tester/)
+[![OpenAPI versions](https://img.shields.io/badge/OpenAPI-3.0.x%20%7C%203.1.x-green.svg?logo=openapiinitiative&logoColor=green
+)](https://pypi.org/project/django-contract-tester/)
 
 
 # Django Contract Tester

--- a/openapi_tester/response_handler.py
+++ b/openapi_tester/response_handler.py
@@ -51,23 +51,23 @@ class ResponseHandler(ABC):
         Normalize the query params to be validated against the schema.
         This is necessary because the query params are always strings in the request.
         """
-        normalized_query_params = {}
-        for query_param in query_params.keys():
+        normalized_query_params: dict = {}
+        for key, value in query_params.items():
             try:
-                normalized_query_params[query_param] = float(query_params[query_param])
-                if normalized_query_params[query_param].is_integer():
-                    normalized_query_params[query_param] = int(
-                        normalized_query_params[query_param]
-                    )
+                number = float(value)
+                normalized_query_params[key] = (
+                    int(number) if number.is_integer() else number
+                )
             except ValueError:
-                if query_param.lower() == "true":
-                    normalized_query_params[query_param] = True
-                elif query_param.lower() == "false":
-                    normalized_query_params[query_param] = False
-                elif query_param.lower() == "null":
-                    normalized_query_params[query_param] = None  # type: ignore[assignment]
+                lowered = value.lower()
+                if lowered == "true":
+                    normalized_query_params[key] = True
+                elif lowered == "false":
+                    normalized_query_params[key] = False
+                elif lowered == "null":
+                    normalized_query_params[key] = None
                 else:
-                    normalized_query_params[query_param] = query_params[query_param]
+                    normalized_query_params[key] = value
         return normalized_query_params
 
     @abstractmethod

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -193,18 +193,23 @@ def normalize_query_param_value(param_schema: dict, value: Any) -> Any:
     """
     schema_type = param_schema.get("type")
 
-    if schema_type == "array" and isinstance(value, str):
+    if schema_type == "array" and not isinstance(value, list):
         items_type = param_schema.get("items", {}).get("type")
 
-        for delimiter in [",", "|", ";"]:
-            if delimiter in value:
-                items = [
-                    item.strip() for item in value.split(delimiter) if item.strip()
-                ]
-                return [_coerce_scalar(items_type, item) for item in items]
+        if isinstance(value, str):
+            for delimiter in [",", "|", ";"]:
+                if delimiter in value:
+                    items = [
+                        item.strip() for item in value.split(delimiter) if item.strip()
+                    ]
+                    return [_coerce_scalar(items_type, item) for item in items]
 
-        if not value:
+            if not value:
+                return []
+            return [_coerce_scalar(items_type, value)]
+
+        if value is None:
             return []
-        return [_coerce_scalar(items_type, value)]
+        return [value]
 
     return value

--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -135,8 +135,8 @@ def query_params_to_object(query_params: list[dict[str, Any]]) -> dict[str, Any]
 
 def should_validate_query_param(param_schema_section: dict, request_value: Any) -> bool:
     """
-    Checks if query paramter should be validated.
-    If the query paramter is a raw string (without any format or constraints) it should not be validated.
+    Checks if query parameter should be validated.
+    If the query parameter is a raw string (without any format or constraints) it should not be validated.
     If the query parameter is a string and has a format or constraints, it should be validated if the request value (after normalization) is a string.
     """
 
@@ -148,12 +148,41 @@ def should_validate_query_param(param_schema_section: dict, request_value: Any) 
     return True
 
 
+def _coerce_scalar(schema_type: str | None, raw: str) -> Any:
+    """
+    Best-effort coercion of a raw string to the Python type implied by an
+    OpenAPI scalar schema type. Falls back to the raw string on failure or
+    when the target type is unknown.
+    """
+    if schema_type == "integer":
+        try:
+            return int(raw)
+        except ValueError:
+            return raw
+    if schema_type == "number":
+        try:
+            return float(raw)
+        except ValueError:
+            return raw
+    if schema_type == "boolean":
+        lowered = raw.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        return raw
+    return raw
+
+
 def normalize_query_param_value(param_schema: dict, value: Any) -> Any:
     """
     Normalize query parameter values based on their schema type.
 
     Specifically handles the case where an array-type parameter comes as a
-    delimited string (e.g., "a,b,c" or "a|b|c").
+    delimited string (e.g., "a,b,c" or "a|b|c"). When the schema declares an
+    ``items.type`` (integer / number / boolean), each parsed item is coerced
+    to the corresponding Python type so the downstream validator receives
+    values of the expected type.
 
     Args:
         param_schema: The OpenAPI schema for the parameter
@@ -164,16 +193,18 @@ def normalize_query_param_value(param_schema: dict, value: Any) -> Any:
     """
     schema_type = param_schema.get("type")
 
-    # If schema expects array but we got a string, try to parse it
     if schema_type == "array" and isinstance(value, str):
-        # Try common delimiters
+        items_type = param_schema.get("items", {}).get("type")
+
         for delimiter in [",", "|", ";"]:
             if delimiter in value:
-                # Split and strip whitespace
-                return [item.strip() for item in value.split(delimiter) if item.strip()]
+                items = [
+                    item.strip() for item in value.split(delimiter) if item.strip()
+                ]
+                return [_coerce_scalar(items_type, item) for item in items]
 
-        # No delimiter found - treat as single-item array
-        # This allows "?ids=single_value" to work
-        return [value] if value else []
+        if not value:
+            return []
+        return [_coerce_scalar(items_type, value)]
 
     return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-contract-tester"
-version = "1.8.0"
+version = "1.8.1"
 description = "Test utility for validating OpenAPI response documentation"
 authors = [
     {name = "Matías Cárdenas", email = "cardenasmatias.1990@gmail.com"},

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -10,24 +10,6 @@ from openapi_tester.response_handler import (
 )
 
 
-@pytest.fixture
-def normalize():
-    return ResponseHandler._normalize_query_params
-
-
-@pytest.fixture
-def build_ninja_handler():
-    def _build(path: str) -> DjangoNinjaResponseHandler:
-        return DjangoNinjaResponseHandler(
-            "GET",
-            path,
-            None,
-            response=MagicMock(),
-        )
-
-    return _build
-
-
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
@@ -37,8 +19,8 @@ def build_ninja_handler():
         ({"amount": "2.0"}, {"amount": 2}),
     ],
 )
-def test_normalize_query_params_casts_numeric_strings(normalize, raw, expected):
-    assert normalize(raw) == expected
+def test_normalize_query_params_casts_numeric_strings(raw: dict, expected: dict):
+    assert ResponseHandler._normalize_query_params(raw) == expected
 
 
 @pytest.mark.parametrize(
@@ -51,13 +33,18 @@ def test_normalize_query_params_casts_numeric_strings(normalize, raw, expected):
     ],
 )
 def test_normalize_query_params_handles_special_and_plain_strings(
-    normalize, raw, expected
+    raw: dict, expected: dict
 ):
-    assert normalize(raw) == expected
+    assert ResponseHandler._normalize_query_params(raw) == expected
 
 
-def test_django_ninja_handler_parses_and_normalizes_query_string(build_ninja_handler):
-    handler = build_ninja_handler("/api/pets?page=1&active=true&name=doggie")
+def test_django_ninja_handler_parses_and_normalizes_query_string():
+    handler = DjangoNinjaResponseHandler(
+        "GET",
+        "/api/pets?page=1&active=true&name=doggie",
+        None,
+        response=MagicMock(),
+    )
 
     assert handler.request.query_params == {
         "page": 1,
@@ -66,9 +53,12 @@ def test_django_ninja_handler_parses_and_normalizes_query_string(build_ninja_han
     }
 
 
-def test_django_ninja_handler_returns_empty_query_params_when_missing(
-    build_ninja_handler,
-):
-    handler = build_ninja_handler("/api/pets")
+def test_django_ninja_handler_returns_empty_query_params_when_missing():
+    handler = DjangoNinjaResponseHandler(
+        "GET",
+        "/api/pets",
+        None,
+        response=MagicMock(),
+    )
 
     assert handler.request.query_params == {}

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from openapi_tester.response_handler import (
+    DjangoNinjaResponseHandler,
+    ResponseHandler,
+)
+
+
+@pytest.fixture
+def normalize():
+    return ResponseHandler._normalize_query_params
+
+
+@pytest.fixture
+def build_ninja_handler():
+    def _build(path: str) -> DjangoNinjaResponseHandler:
+        return DjangoNinjaResponseHandler(
+            "GET",
+            path,
+            None,
+            response=MagicMock(),
+        )
+
+    return _build
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ({"page": "1"}, {"page": 1}),
+        ({"count": "10", "price": "9.5"}, {"count": 10, "price": 9.5}),
+        ({"temperature": "-3.14"}, {"temperature": -3.14}),
+        ({"amount": "2.0"}, {"amount": 2}),
+    ],
+)
+def test_normalize_query_params_casts_numeric_strings(normalize, raw, expected):
+    assert normalize(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ({"active": "true"}, {"active": True}),
+        ({"active": "false"}, {"active": False}),
+        ({"value": "null"}, {"value": None}),
+        ({"name": "doggie"}, {"name": "doggie"}),
+    ],
+)
+def test_normalize_query_params_handles_special_and_plain_strings(
+    normalize, raw, expected
+):
+    assert normalize(raw) == expected
+
+
+def test_django_ninja_handler_parses_and_normalizes_query_string(build_ninja_handler):
+    handler = build_ninja_handler("/api/pets?page=1&active=true&name=doggie")
+
+    assert handler.request.query_params == {
+        "page": 1,
+        "active": True,
+        "name": "doggie",
+    }
+
+
+def test_django_ninja_handler_returns_empty_query_params_when_missing(
+    build_ninja_handler,
+):
+    handler = build_ninja_handler("/api/pets")
+
+    assert handler.request.query_params == {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -242,3 +242,27 @@ def test_normalize_query_param_value_falls_back_on_invalid_items(
     param_schema = {"type": "array", "items": {"type": items_type}}
 
     assert normalize_query_param_value(param_schema, raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("items_type", "value", "expected"),
+    [
+        ("integer", 155, [155]),
+        ("number", 3.14, [3.14]),
+        ("boolean", True, [True]),
+        ("boolean", False, [False]),
+        ("integer", None, []),
+    ],
+)
+def test_normalize_query_param_value_wraps_precoerced_scalars_as_single_item_array(
+    items_type, value, expected
+):
+    param_schema = {"type": "array", "items": {"type": items_type}}
+
+    assert normalize_query_param_value(param_schema, value) == expected
+
+
+def test_normalize_query_param_value_leaves_lists_untouched():
+    param_schema = {"type": "array", "items": {"type": "integer"}}
+
+    assert normalize_query_param_value(param_schema, [1, 2, 3]) == [1, 2, 3]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from openapi_tester.utils import (
     get_required_keys,
     merge_objects,
@@ -206,3 +208,37 @@ def test_normalize_query_param_value():
     assert normalize_query_param_value({"type": "array"}, "1,2,3") == ["1", "2", "3"]
     assert normalize_query_param_value({"type": "array"}, "1|2|3") == ["1", "2", "3"]
     assert normalize_query_param_value({"type": "array"}, "1;2;3") == ["1", "2", "3"]
+
+
+@pytest.mark.parametrize(
+    ("items_type", "raw", "expected"),
+    [
+        ("integer", "1,2,3", [1, 2, 3]),
+        ("number", "1.5|2.5|3", [1.5, 2.5, 3.0]),
+        ("boolean", "true;false;true", [True, False, True]),
+        ("integer", "5", [5]),
+        ("string", "a,b,c", ["a", "b", "c"]),
+    ],
+)
+def test_normalize_query_param_value_coerces_items_by_items_type(
+    items_type, raw, expected
+):
+    param_schema = {"type": "array", "items": {"type": items_type}}
+
+    assert normalize_query_param_value(param_schema, raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("items_type", "raw", "expected"),
+    [
+        ("integer", "1,oops,3", [1, "oops", 3]),
+        ("number", "1.5,nope", [1.5, "nope"]),
+        ("boolean", "true,maybe", [True, "maybe"]),
+    ],
+)
+def test_normalize_query_param_value_falls_back_on_invalid_items(
+    items_type, raw, expected
+):
+    param_schema = {"type": "array", "items": {"type": items_type}}
+
+    assert normalize_query_param_value(param_schema, raw) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "django-contract-tester"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "4.2.27", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
# Fix: type normalization for query parameter validation

Closes #74.

## Problem

Two related bugs in query-parameter normalization produced false-positive errors:

- **Boolean / null coercion looked at the key, not the value.** In `ResponseHandler._normalize_query_params`, the `except ValueError` branch was comparing `query_param.lower()` (the dict key) instead of the value. So `?has_attachments=False` stayed as the string `"False"` and validation failed with `Expected: a "boolean" type value, Received: "False"`.

- **Array items were never coerced to their declared type.** `normalize_query_param_value` split a delimited string like `?id__in=155,156` into `["155", "156"]` and handed the strings to the validator, which then failed with `Expected: an "integer" type value, Received: "155"`.

## Fix

- Rewrote `_normalize_query_params` to iterate with `.items()` so key/value can no longer be confused, and normalized the numeric branch to compute the `float` once.
- Added a small `_coerce_scalar(schema_type, raw)` helper in `utils.py` and use into `normalize_query_param_value` so each array item is cast to the type declared in `items.type` (`integer` / `number` / `boolean`). Invalid or unknown types fall back to the raw string so the schema validator still emits its usual contextual error instead of raising a `ValueError`.
