### PR TITLE
update serialize_json decorator to pass content_type argument

### DIFF
--- a/openapi_tester/utils.py
+++ b/openapi_tester/utils.py
@@ -79,7 +79,7 @@ def serialize_json(func):
                 kwargs["data"] = orjson.dumps(data)
             except (TypeError, OverflowError):
                 kwargs["data"] = data
-        return func(*args, **kwargs)
+        return func(*args, content_type=content_type, **kwargs)
 
     return wrapper
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from openapi_tester.utils import (
     merge_objects,
     normalize_query_param_value,
     query_params_to_object,
+    serialize_json,
     serialize_schema_section_data,
     should_validate_query_param,
 )
@@ -45,6 +46,39 @@ def test_merge_objects():
         "properties": {"key1": {"type": "string"}, "key2": {"type": "string"}},
     }
     assert sort_object(merge_objects(test_schemas)) == sort_object(expected)
+
+
+def test_serialize_json_decorator():
+    @serialize_json
+    def dummy_function(*args, **kwargs):
+        return kwargs
+
+    data = {"key": "value"}
+    result = dummy_function(data=data)
+    assert result["data"] == b'{"key":"value"}'
+    assert result["content_type"] == "application/json"
+
+
+def test_serialize_json_decorator_content_type_application_json():
+    @serialize_json
+    def dummy_function(*args, **kwargs):
+        return kwargs
+
+    data = {"key": "value"}
+    result = dummy_function(data=data, content_type="application/json")
+    assert result["data"] == b'{"key":"value"}'
+    assert result["content_type"] == "application/json"
+
+
+def test_serialize_json_decorator_content_type_text_plain():
+    @serialize_json
+    def dummy_function(*args, **kwargs):
+        return kwargs
+
+    data = "value"
+    result = dummy_function(data=data, content_type="text/plain")
+    assert result["data"] == "value"
+    assert result["content_type"] == "text/plain"
 
 
 def test_serialize_schema_section_data():


### PR DESCRIPTION
The `serialize_json` decorator gobbles up the passed `content_type` argument and consequently it isn't passed through to the decorated function.  The PR fixes that and adds some tests.